### PR TITLE
Implement report generation logic in TransparencyManager

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,5 +51,10 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.52.0" />
     <PackageVersion Include="Qdrant.Client" Version="1.10.0" />
+    <!-- Testing -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>
 </Project>

--- a/src/MetacognitiveLayer/ReasoningTransparency/ReasoningTransparency.csproj
+++ b/src/MetacognitiveLayer/ReasoningTransparency/ReasoningTransparency.csproj
@@ -7,15 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="TransparencyManager.cs" />
+    <PackageReference Include="Azure.AI.OpenAI"/>
+    <PackageReference Include="Azure.Messaging.EventGrid" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI"/>
-    <PackageReference Include="Azure.Messaging.EventGrid" />
-
-    <PackageReference Include="System.Text.Json" />
+    <ProjectReference Include="..\..\Shared\CognitiveMesh.Shared.csproj" />
   </ItemGroup>
 
 </Project>
-

--- a/src/MetacognitiveLayer/ReasoningTransparency/Strategies/IReportFormatStrategy.cs
+++ b/src/MetacognitiveLayer/ReasoningTransparency/Strategies/IReportFormatStrategy.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using CognitiveMesh.MetacognitiveLayer.ReasoningTransparency;
+
+namespace CognitiveMesh.MetacognitiveLayer.ReasoningTransparency.Strategies
+{
+    /// <summary>
+    /// Strategy interface for formatting transparency reports.
+    /// </summary>
+    public interface IReportFormatStrategy
+    {
+        /// <summary>
+        /// Gets the format identifier (e.g., "json", "markdown").
+        /// </summary>
+        string Format { get; }
+
+        /// <summary>
+        /// Generates a report for the given trace and aggregations.
+        /// </summary>
+        /// <param name="trace">The reasoning trace to report on.</param>
+        /// <param name="aggregations">Calculated aggregations and statistics.</param>
+        /// <returns>The formatted report as a string.</returns>
+        string GenerateReport(ReasoningTrace trace, Dictionary<string, object> aggregations);
+    }
+}

--- a/src/MetacognitiveLayer/ReasoningTransparency/Strategies/JsonReportFormatStrategy.cs
+++ b/src/MetacognitiveLayer/ReasoningTransparency/Strategies/JsonReportFormatStrategy.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using CognitiveMesh.MetacognitiveLayer.ReasoningTransparency;
+
+namespace CognitiveMesh.MetacognitiveLayer.ReasoningTransparency.Strategies
+{
+    /// <summary>
+    /// Generates transparency reports in JSON format.
+    /// </summary>
+    public class JsonReportFormatStrategy : IReportFormatStrategy
+    {
+        /// <inheritdoc/>
+        public string Format => "json";
+
+        /// <inheritdoc/>
+        public string GenerateReport(ReasoningTrace trace, Dictionary<string, object> aggregations)
+        {
+            var reportData = new
+            {
+                TraceId = trace.Id,
+                TraceName = trace.Name,
+                GeneratedAt = DateTime.UtcNow,
+                Summary = aggregations,
+                Steps = trace.Steps
+            };
+
+            return JsonSerializer.Serialize(reportData, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+        }
+    }
+}

--- a/src/MetacognitiveLayer/ReasoningTransparency/Strategies/MarkdownReportFormatStrategy.cs
+++ b/src/MetacognitiveLayer/ReasoningTransparency/Strategies/MarkdownReportFormatStrategy.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CognitiveMesh.MetacognitiveLayer.ReasoningTransparency;
+
+namespace CognitiveMesh.MetacognitiveLayer.ReasoningTransparency.Strategies
+{
+    /// <summary>
+    /// Generates transparency reports in Markdown format.
+    /// </summary>
+    public class MarkdownReportFormatStrategy : IReportFormatStrategy
+    {
+        /// <inheritdoc/>
+        public string Format => "markdown";
+
+        /// <inheritdoc/>
+        public string GenerateReport(ReasoningTrace trace, Dictionary<string, object> aggregations)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"# Transparency Report: {trace.Name}");
+            sb.AppendLine();
+            sb.AppendLine($"**Trace ID:** {trace.Id}");
+            sb.AppendLine($"**Generated At:** {DateTime.UtcNow}");
+            sb.AppendLine($"**Description:** {trace.Description}");
+            sb.AppendLine();
+
+            sb.AppendLine("## Summary");
+            foreach (var kvp in aggregations)
+            {
+                sb.AppendLine($"- **{FormatKey(kvp.Key)}**: {kvp.Value}");
+            }
+            sb.AppendLine();
+
+            sb.AppendLine("## Reasoning Steps");
+
+            if (trace.Steps != null && trace.Steps.Any())
+            {
+                foreach (var step in trace.Steps.OrderBy(s => s.Timestamp))
+                {
+                    sb.AppendLine($"### Step: {step.Name}");
+                    sb.AppendLine($"- **ID**: {step.Id}");
+                    sb.AppendLine($"- **Timestamp**: {step.Timestamp}");
+                    sb.AppendLine($"- **Confidence**: {step.Confidence:P}");
+                    sb.AppendLine($"- **Description**: {step.Description}");
+
+                    if (step.Inputs != null && step.Inputs.Any())
+                    {
+                        sb.AppendLine("- **Inputs**:");
+                        foreach (var input in step.Inputs)
+                        {
+                            sb.AppendLine($"  - {input.Key}: {input.Value}");
+                        }
+                    }
+
+                    if (step.Outputs != null && step.Outputs.Any())
+                    {
+                        sb.AppendLine("- **Outputs**:");
+                        foreach (var output in step.Outputs)
+                        {
+                            sb.AppendLine($"  - {output.Key}: {output.Value}");
+                        }
+                    }
+
+                    sb.AppendLine();
+                }
+            }
+            else
+            {
+                sb.AppendLine("*No steps recorded.*");
+            }
+
+            return sb.ToString();
+        }
+
+        private string FormatKey(string key)
+        {
+            // Simple helper to format keys like "AverageConfidence" to "Average Confidence"
+            // For now, just return as is or do simple spacing
+            return System.Text.RegularExpressions.Regex.Replace(key, "([a-z])([A-Z])", "$1 $2");
+        }
+    }
+}

--- a/tests/TestProject/MetacognitiveLayer/TransparencyManagerTests.cs
+++ b/tests/TestProject/MetacognitiveLayer/TransparencyManagerTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using CognitiveMesh.MetacognitiveLayer.ReasoningTransparency;
+using CognitiveMesh.Shared.Interfaces;
+
+namespace CognitiveMesh.Tests.MetacognitiveLayer
+{
+    public class TransparencyManagerTests
+    {
+        private readonly MockLogger<TransparencyManager> _logger;
+        private readonly MockKnowledgeGraphManager _graphManager;
+        private readonly TransparencyManager _manager;
+
+        public TransparencyManagerTests()
+        {
+            _logger = new MockLogger<TransparencyManager>();
+            _graphManager = new MockKnowledgeGraphManager();
+            _manager = new TransparencyManager(_logger, _graphManager);
+        }
+
+        [Fact]
+        public async Task LogReasoningStepAsync_ShouldCreateTraceAndStep()
+        {
+            // Arrange
+            var step = new ReasoningStep
+            {
+                Id = "step-1",
+                TraceId = "trace-1",
+                Name = "Test Step",
+                Description = "Testing",
+                Timestamp = DateTime.UtcNow,
+                Confidence = 0.9f
+            };
+
+            // Act
+            await _manager.LogReasoningStepAsync(step);
+
+            // Assert
+            var trace = await _graphManager.GetNodeAsync<ReasoningTrace>("trace-1");
+            Assert.NotNull(trace);
+            Assert.Equal("trace-1", trace.Id);
+
+            var storedStep = await _graphManager.GetNodeAsync<ReasoningStep>("step-1");
+            Assert.NotNull(storedStep);
+            Assert.Equal("step-1", storedStep.Id);
+
+            // Check relationship
+            Assert.Contains(_graphManager.Relationships, r =>
+                r.SourceId == "trace-1" &&
+                r.TargetId == "step-1" &&
+                r.Type == "HAS_STEP");
+        }
+
+        [Fact]
+        public async Task GenerateTransparencyReportAsync_Json_ShouldReturnValidReport()
+        {
+            // Arrange
+            var traceId = "trace-report-json";
+            var step1 = new ReasoningStep
+            {
+                Id = "s1",
+                TraceId = traceId,
+                Name = "Step 1",
+                Timestamp = DateTime.UtcNow.AddMinutes(-10),
+                Confidence = 0.8f,
+                Metadata = new Dictionary<string, object> { ["model"] = "gpt-4" }
+            };
+            var step2 = new ReasoningStep
+            {
+                Id = "s2",
+                TraceId = traceId,
+                Name = "Step 2",
+                Timestamp = DateTime.UtcNow,
+                Confidence = 0.9f,
+                Metadata = new Dictionary<string, object> { ["model"] = "gpt-3.5" }
+            };
+
+            await _manager.LogReasoningStepAsync(step1);
+            await _manager.LogReasoningStepAsync(step2);
+
+            // Act
+            var reports = await _manager.GenerateTransparencyReportAsync(traceId, "json");
+            var report = reports.Single();
+
+            // Assert
+            Assert.Equal(traceId, report.TraceId);
+            Assert.Equal("json", report.Format);
+            Assert.Contains("gpt-4", report.Content!);
+            Assert.Contains("gpt-3.5", report.Content!);
+            Assert.Contains("AverageConfidence", report.Content!);
+            Assert.Contains("0.85", report.Content!); // Average of 0.8 and 0.9
+        }
+
+        [Fact]
+        public async Task GenerateTransparencyReportAsync_Markdown_ShouldReturnValidReport()
+        {
+            // Arrange
+            var traceId = "trace-report-md";
+            var step1 = new ReasoningStep
+            {
+                Id = "s1",
+                TraceId = traceId,
+                Name = "Analysis",
+                Timestamp = DateTime.UtcNow,
+                Confidence = 0.95f
+            };
+
+            await _manager.LogReasoningStepAsync(step1);
+
+            // Act
+            var reports = await _manager.GenerateTransparencyReportAsync(traceId, "markdown");
+            var report = reports.Single();
+
+            // Assert
+            Assert.Equal("markdown", report.Format);
+            Assert.StartsWith("# Transparency Report", report.Content);
+            Assert.Contains("**Trace ID:** trace-report-md", report.Content!);
+            Assert.Contains("### Step: Analysis", report.Content!);
+        }
+    }
+
+    // --- Mocks ---
+
+    public class MockLogger<T> : ILogger<T>
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+    }
+
+    public class MockKnowledgeGraphManager : IKnowledgeGraphManager
+    {
+        private readonly Dictionary<string, object> _nodes = new Dictionary<string, object>();
+        public readonly List<(string SourceId, string TargetId, string Type)> Relationships = new List<(string, string, string)>();
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task AddNodeAsync<T>(string nodeId, T properties, string? label = null, CancellationToken cancellationToken = default) where T : class
+        {
+            _nodes[nodeId] = properties;
+            return Task.CompletedTask;
+        }
+
+        public Task AddRelationshipAsync(string sourceNodeId, string targetNodeId, string relationshipType, Dictionary<string, object>? properties = null, CancellationToken cancellationToken = default)
+        {
+            Relationships.Add((sourceNodeId, targetNodeId, relationshipType));
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<Dictionary<string, object>>> QueryAsync(string query, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(Enumerable.Empty<Dictionary<string, object>>());
+        }
+
+        public Task<T?> GetNodeAsync<T>(string nodeId, CancellationToken cancellationToken = default) where T : class
+        {
+            if (_nodes.TryGetValue(nodeId, out var node) && node is T typedNode)
+            {
+                return Task.FromResult<T?>(typedNode);
+            }
+            return Task.FromResult<T?>(null);
+        }
+
+        public Task UpdateNodeAsync<T>(string nodeId, T properties, CancellationToken cancellationToken = default) where T : class
+        {
+            _nodes[nodeId] = properties;
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteNodeAsync(string nodeId, CancellationToken cancellationToken = default)
+        {
+            _nodes.Remove(nodeId);
+            return Task.CompletedTask;
+        }
+
+        public Task<IEnumerable<T>> FindNodesAsync<T>(Dictionary<string, object> properties, CancellationToken cancellationToken = default) where T : class
+        {
+            var result = new List<T>();
+            foreach (var node in _nodes.Values)
+            {
+                if (node is T typedNode)
+                {
+                    bool match = true;
+                    var type = typeof(T);
+                    foreach (var kvp in properties)
+                    {
+                        var prop = type.GetProperty(kvp.Key);
+                        if (prop == null)
+                        {
+                            match = false;
+                            break;
+                        }
+
+                        var val = prop.GetValue(typedNode);
+                        if (!object.Equals(val, kvp.Value))
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match)
+                    {
+                        result.Add(typedNode);
+                    }
+                }
+            }
+            return Task.FromResult<IEnumerable<T>>(result);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/tests/TestProject/TestProject.csproj
+++ b/tests/TestProject/TestProject.csproj
@@ -4,15 +4,20 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MetacognitiveLayer\ReasoningTransparency\ReasoningTransparency.csproj" />
+    <ProjectReference Include="..\..\src\Shared\CognitiveMesh.Shared.csproj" />
+  </ItemGroup>
 </Project>
-net bui


### PR DESCRIPTION
- Implemented `GenerateTransparencyReportAsync` with support for JSON and Markdown formats using Strategy pattern.
- Implemented `LogReasoningStepAsync` and `GetReasoningTraceAsync` to persist traces to Knowledge Graph.
- Updated domain models (`ReasoningTrace`, `ReasoningStep`) to use nullable reference types.
- Added unit tests for `TransparencyManager`.
- Fixed `ReasoningTransparency.csproj` references and `TestProject.csproj` setup.
- Complied with .NET 9 strict build requirements.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
