### PR TITLE
Fix gh-pages deploy permissions

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -60,7 +60,9 @@ jobs:
     needs: validate
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -93,8 +95,6 @@ jobs:
         user_name: 'GitHub Action'
         user_email: 'action@github.com'
         commit_message: 'Deploy API documentation'
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
 
   notify:
     name: Notify on Failure


### PR DESCRIPTION
## Summary
- Added `permissions: contents: write` to the deploy job in `api-docs.yml` so `peaceiris/actions-gh-pages@v4` can push to the `gh-pages` branch
- Removed unused `ACTIONS_DEPLOY_KEY` env var (the action uses `github_token`, not a deploy key)

## Test plan
- [ ] CI passes on this PR
- [ ] Next deploy to gh-pages succeeds (triggers on `main` push or `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API documentation deployment workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->