### PR TITLE
Potential fix for code scanning alert no. 545: Unused variable, import, function or class

### DIFF
--- a/src/UILayer/web/src/components/Nexus/index.tsx
+++ b/src/UILayer/web/src/components/Nexus/index.tsx
@@ -363,22 +363,6 @@ export default function Nexus({
   }
 
   // Enhanced mode drag handlers
-  const handleDragStart = useCallback((type: "nexus" | "icon", data?: unknown, event?: React.MouseEvent) => {
-    if (mode !== "enhanced") return
-    if (!event) return
-    nexusDragStart()
-    startDrag({
-      id: `${type}-${Date.now()}`,
-      type: "nexus",
-      size: "small",
-      position: { x: 0, y: 0 },
-      isDocked: false,
-      zIndex: 100,
-    }, event)
-    if (enableAudio) playSound("click")
-    if (onDragStart) onDragStart()
-  }, [mode, startDrag, enableAudio, playSound, onDragStart, nexusDragStart])
-
   const handleDragEnd = useCallback(() => {
     if (mode !== "enhanced") return
     nexusDragEnd()


### PR DESCRIPTION
Potential fix for [https://github.com/phoenixvc/cognitive-mesh/security/code-scanning/545](https://github.com/phoenixvc/cognitive-mesh/security/code-scanning/545)

To fix the problem, we should remove the unused variable `handleDragStart`. This eliminates dead code and the associated (albeit small) runtime overhead of keeping an extra callback and its dependencies.

Concretely, in `src/UILayer/web/src/components/Nexus/index.tsx`, delete the entire `const handleDragStart = useCallback(...)` definition (lines 366–380 in the snippet), including its dependency array, without altering adjacent handlers like `handlePinToggle`, `handleExpandToggle`, `handleModuleClick`, or `handleDragEnd`. No new methods, imports, or definitions are needed, and we don’t need to modify any existing imports because removing an internal function does not affect them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed drag-and-drop functionality from a component in enhanced mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->