### PR TITLE
feat: route model calls through Sluice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,15 @@
-# ────────────── Primary Azure OpenAI ──────────────
-AZURE_OPENAI_ENDPOINT=https://your-primary-endpoint.openai.azure.com/
-AZURE_OPENAI_KEY=your_primary_key_here
-AZURE_OPENAI_DEPLOYMENT_GPT35=your-gpt35-deployment-name
-AZURE_OPENAI_DEPLOYMENT_ROUTER=your-model-router-name
+# ────────────── Sluice model routing ──────────────
+# Cognitive Mesh routes model calls through Sluice. Do not configure provider
+# keys here for shared/prod deployments.
+SLUICE_BASE_URL=https://sluice.example.com
+SLUICE_API_KEY=
+SLUICE_MODEL=default
+SLUICE_MAX_TOKENS=16384
+
+# Direct providers are for local mocks or explicit migration shims only.
+ALLOW_DIRECT_MODEL_PROVIDER=false
 
 # ────────────── Cognitive Mesh Frontend Auth ──────────────
 NEXT_PUBLIC_API_BASE_URL=http://localhost:5000
 NEXT_PUBLIC_MYSTIRA_AUTH_CLIENT_ID=d8182e32-4dda-4fc9-83bf-b5d517bc9528
 NEXT_PUBLIC_MYSTIRA_TENANT_ID=9530cd32-9e33-47f0-9247-ed964730b580
-
-# ────────────── Secondary "SAF" Azure OpenAI ──────────────
-AZURE_OPENAI_ENDPOINT_SAF=https://your-saf-endpoint.openai.azure.com/
-AZURE_OPENAI_KEY_SAF=your_saf_key_here
-AZURE_OPENAI_DEPLOYMENT_4O=your-gpt4o-deployment-name
-AZURE_OPENAI_DEPLOYMENT_GPT41=your-gpt41-deployment-name
-AZURE_OPENAI_DEPLOYMENT_EMBEDDINGS=your-embeddings-deployment-name

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -84,7 +84,7 @@ variable "enable_qdrant" {
 }
 
 variable "enable_openai" {
-  description = "Whether to deploy a dedicated Azure OpenAI resource."
+  description = "Whether to deploy a dedicated Azure OpenAI resource. Keep false for Cognitive Mesh prod; model egress should route through Sluice unless an exception is approved."
   type        = bool
   default     = false
 }
@@ -158,7 +158,7 @@ variable "qdrant_image" {
 # ---------- OpenAI ----------
 
 variable "openai_model_deployments" {
-  description = "Map of Azure OpenAI model deployments."
+  description = "Map of Azure OpenAI model deployments for explicit direct-provider exceptions only. Production Cognitive Mesh should use Sluice routing instead."
   type = map(object({
     model_name    = string
     model_version = string

--- a/src/MetacognitiveLayer/Protocols/LLM/SluiceLLMProvider.cs
+++ b/src/MetacognitiveLayer/Protocols/LLM/SluiceLLMProvider.cs
@@ -1,0 +1,171 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace MetacognitiveLayer.Protocols.LLM
+{
+    /// <summary>
+    /// LLM provider that routes protocol-level completions and embeddings through Sluice.
+    /// </summary>
+    public sealed class SluiceLLMProvider : ILLMProvider, IDisposable
+    {
+        private readonly string _baseUrl;
+        private readonly string _apiKey;
+        private readonly string _defaultModel;
+        private readonly ILogger<SluiceLLMProvider>? _logger;
+        private readonly JsonSerializerOptions _jsonOptions;
+        private readonly HttpClient _httpClient;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SluiceLLMProvider"/> class.
+        /// </summary>
+        /// <param name="baseUrl">The Sluice API base URL.</param>
+        /// <param name="apiKey">Optional Sluice bearer token or API key.</param>
+        /// <param name="defaultModel">The default Sluice model route.</param>
+        /// <param name="logger">Optional logger instance.</param>
+        public SluiceLLMProvider(
+            string baseUrl,
+            string apiKey = "",
+            string defaultModel = "default",
+            ILogger<SluiceLLMProvider>? logger = null)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl))
+                throw new ArgumentException("Sluice base URL is required.", nameof(baseUrl));
+
+            _baseUrl = baseUrl.TrimEnd('/');
+            _apiKey = apiKey ?? string.Empty;
+            _defaultModel = string.IsNullOrWhiteSpace(defaultModel) ? "default" : defaultModel;
+            _logger = logger;
+            _jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                WriteIndented = false
+            };
+            _httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(_baseUrl),
+                Timeout = TimeSpan.FromSeconds(120)
+            };
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            if (!string.IsNullOrWhiteSpace(_apiKey))
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> CompletePromptAsync(string prompt, LLMOptions? options = null)
+        {
+            options ??= new LLMOptions();
+            _logger?.LogDebug("Routing protocol completion through Sluice model route {Model}", options.Model);
+
+            var messages = string.IsNullOrWhiteSpace(options.SystemMessage)
+                ? new[] { new { role = "user", content = prompt } }
+                : new[]
+                {
+                    new { role = "system", content = options.SystemMessage },
+                    new { role = "user", content = prompt }
+                };
+
+            var requestBody = new
+            {
+                model = string.IsNullOrWhiteSpace(options.Model) || options.Model == "default" ? _defaultModel : options.Model,
+                messages,
+                temperature = Math.Clamp(options.Temperature, 0f, 2f),
+                max_tokens = options.MaxTokens,
+                stream = false
+            };
+
+            using var content = CreateJsonContent(requestBody);
+            var responseBody = await PostJsonAsync("/v1/chat/completions", content);
+            return ParseCompletion(responseBody);
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> CreateEmbeddingAsync(string text)
+        {
+            var requestBody = new
+            {
+                model = _defaultModel,
+                input = text
+            };
+
+            using var content = CreateJsonContent(requestBody);
+            var responseBody = await PostJsonAsync("/v1/embeddings", content);
+            return ParseEmbedding(responseBody);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _httpClient.Dispose();
+            _disposed = true;
+        }
+
+        private StringContent CreateJsonContent(object value)
+        {
+            var json = JsonSerializer.Serialize(value, _jsonOptions);
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private async Task<string> PostJsonAsync(string path, HttpContent content)
+        {
+            var response = await _httpClient.PostAsync(path, content);
+            var responseBody = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new InvalidOperationException(
+                    $"Sluice request failed with status {(int)response.StatusCode}: {responseBody}");
+            }
+
+            return responseBody;
+        }
+
+        private static string ParseCompletion(string responseBody)
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("choices", out var choices) && choices.GetArrayLength() > 0)
+            {
+                var firstChoice = choices[0];
+                if (firstChoice.TryGetProperty("message", out var message) &&
+                    message.TryGetProperty("content", out var content))
+                {
+                    return content.GetString()?.Trim() ?? string.Empty;
+                }
+
+                if (firstChoice.TryGetProperty("text", out var text))
+                    return text.GetString()?.Trim() ?? string.Empty;
+            }
+
+            if (root.TryGetProperty("content", out var rootContent))
+                return rootContent.GetString()?.Trim() ?? string.Empty;
+
+            if (root.TryGetProperty("text", out var rootText))
+                return rootText.GetString()?.Trim() ?? string.Empty;
+
+            return responseBody;
+        }
+
+        private static string ParseEmbedding(string responseBody)
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            if (!doc.RootElement.TryGetProperty("data", out var data) || data.GetArrayLength() == 0)
+                return "[]";
+
+            if (!data[0].TryGetProperty("embedding", out var embedding))
+                return "[]";
+
+            var values = embedding.EnumerateArray().Select(e => e.GetSingle()).ToArray();
+            return JsonSerializer.Serialize(values);
+        }
+    }
+}

--- a/src/ReasoningLayer/LLMReasoning/Implementations/MiniMaxClient.cs
+++ b/src/ReasoningLayer/LLMReasoning/Implementations/MiniMaxClient.cs
@@ -1,4 +1,5 @@
 using CognitiveMesh.ReasoningLayer.LLMReasoning.Abstractions;
+using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;

--- a/src/ReasoningLayer/LLMReasoning/Implementations/OpenAIClient.cs
+++ b/src/ReasoningLayer/LLMReasoning/Implementations/OpenAIClient.cs
@@ -1,3 +1,4 @@
+using Azure;
 using Azure.AI.OpenAI;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;

--- a/src/ReasoningLayer/LLMReasoning/Implementations/OpenAICompatibleClient.cs
+++ b/src/ReasoningLayer/LLMReasoning/Implementations/OpenAICompatibleClient.cs
@@ -1,4 +1,5 @@
 using CognitiveMesh.ReasoningLayer.LLMReasoning.Abstractions;
+using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;

--- a/src/ReasoningLayer/LLMReasoning/Implementations/SluiceClient.cs
+++ b/src/ReasoningLayer/LLMReasoning/Implementations/SluiceClient.cs
@@ -1,0 +1,345 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using CognitiveMesh.ReasoningLayer.LLMReasoning.Abstractions;
+using Microsoft.Extensions.Logging;
+using SharedChatMessage = CognitiveMesh.Shared.Interfaces.ChatMessage;
+
+namespace CognitiveMesh.ReasoningLayer.LLMReasoning.Implementations
+{
+    /// <summary>
+    /// Routes Cognitive Mesh language-model operations through Sluice.
+    /// </summary>
+    public sealed class SluiceClient : ILLMClient, CognitiveMesh.Shared.Interfaces.ILLMClient
+    {
+        private readonly string _baseUrl;
+        private readonly string _apiKey;
+        private readonly ILogger<SluiceClient>? _logger;
+        private readonly JsonSerializerOptions _jsonOptions;
+        private HttpClient? _httpClient;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SluiceClient"/> class.
+        /// </summary>
+        /// <param name="baseUrl">The Sluice API base URL.</param>
+        /// <param name="apiKey">Optional Sluice bearer token or API key.</param>
+        /// <param name="modelName">The logical model or route name Sluice should resolve.</param>
+        /// <param name="maxTokens">Maximum output tokens allowed by this client.</param>
+        /// <param name="logger">Optional logger instance.</param>
+        public SluiceClient(
+            string baseUrl,
+            string apiKey = "",
+            string modelName = "default",
+            int maxTokens = 16_384,
+            ILogger<SluiceClient>? logger = null)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl))
+                throw new ArgumentException("Sluice base URL is required.", nameof(baseUrl));
+
+            _baseUrl = baseUrl.TrimEnd('/');
+            _apiKey = apiKey ?? string.Empty;
+            ModelName = string.IsNullOrWhiteSpace(modelName) ? "default" : modelName;
+            MaxTokens = maxTokens > 0 ? maxTokens : 16_384;
+            _logger = logger;
+            _jsonOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                WriteIndented = false
+            };
+        }
+
+        /// <inheritdoc/>
+        public string ModelName { get; }
+
+        /// <inheritdoc/>
+        public int MaxTokens { get; }
+
+        /// <inheritdoc/>
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            if (_httpClient != null)
+                return Task.CompletedTask;
+
+            _httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(_baseUrl),
+                Timeout = TimeSpan.FromSeconds(120)
+            };
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            if (!string.IsNullOrWhiteSpace(_apiKey))
+            {
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+            }
+
+            _logger?.LogInformation("Sluice client initialized for model route {ModelName} at {BaseUrl}", ModelName, _baseUrl);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GenerateCompletionAsync(
+            string prompt,
+            float temperature = 0.7f,
+            int maxTokens = 1000,
+            CancellationToken cancellationToken = default)
+        {
+            return await GenerateChatCompletionAsync(
+                new[] { new SharedChatMessage("user", prompt) },
+                temperature,
+                maxTokens,
+                cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GenerateCompletionAsync(
+            string prompt,
+            int maxTokens = 1000,
+            float temperature = 0.7f,
+            IEnumerable<string>? stopSequences = null,
+            CancellationToken cancellationToken = default)
+        {
+            return await SendCompletionAsync(
+                new[] { new SharedChatMessage("user", prompt) },
+                temperature,
+                maxTokens,
+                stopSequences,
+                cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GenerateChatCompletionAsync(
+            IEnumerable<SharedChatMessage> messages,
+            float temperature = 0.7f,
+            int maxTokens = 1000,
+            CancellationToken cancellationToken = default)
+        {
+            return await SendCompletionAsync(messages, temperature, maxTokens, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Generates a chat completion from reasoning-layer chat messages.
+        /// </summary>
+        /// <param name="messages">The chat messages to send.</param>
+        /// <param name="temperature">The sampling temperature to use.</param>
+        /// <param name="maxTokens">The maximum number of tokens to generate.</param>
+        /// <param name="cancellationToken">Cancellation token for async operations.</param>
+        /// <returns>The generated completion.</returns>
+        public async Task<string> GenerateChatCompletionAsync(
+            IEnumerable<ChatMessage> messages,
+            float temperature = 0.7f,
+            int maxTokens = 1000,
+            CancellationToken cancellationToken = default)
+        {
+            var sharedMessages = messages.Select(m => new SharedChatMessage(m.Role, m.Content));
+            return await SendCompletionAsync(sharedMessages, temperature, maxTokens, null, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task<float[]> GetEmbeddingsAsync(string text, CancellationToken cancellationToken = default)
+        {
+            var results = await GetBatchEmbeddingsAsync(new[] { text }, cancellationToken);
+            return results.FirstOrDefault() ?? [];
+        }
+
+        /// <inheritdoc/>
+        public async Task<float[][]> GetBatchEmbeddingsAsync(IEnumerable<string> texts, CancellationToken cancellationToken = default)
+        {
+            if (texts == null || !texts.Any())
+                throw new ArgumentException("Texts cannot be null or empty.", nameof(texts));
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            var requestBody = new
+            {
+                model = ModelName,
+                input = texts.ToArray()
+            };
+
+            using var content = CreateJsonContent(requestBody);
+            var responseBody = await PostJsonAsync("/v1/embeddings", content, cancellationToken);
+            return ParseEmbeddings(responseBody);
+        }
+
+        /// <inheritdoc/>
+        public Task<float[]> GenerateEmbeddingAsync(string text, CancellationToken cancellationToken = default)
+            => GetEmbeddingsAsync(text, cancellationToken);
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<string>> GenerateMultipleCompletionsAsync(
+            string prompt,
+            int numCompletions = 3,
+            int maxTokens = 500,
+            float temperature = 0.8f,
+            CancellationToken cancellationToken = default)
+        {
+            var results = new List<string>(numCompletions);
+            for (var i = 0; i < numCompletions; i++)
+            {
+                results.Add(await GenerateCompletionAsync(prompt, maxTokens, temperature, cancellationToken: cancellationToken));
+            }
+
+            return results;
+        }
+
+        /// <inheritdoc/>
+        public int GetTokenCount(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return 0;
+
+            return (int)Math.Ceiling(text.Length / 4.0);
+        }
+
+        /// <inheritdoc/>
+        public IChatSession StartChat(string? systemMessage = null)
+        {
+            return new SluiceChatSession(this, systemMessage);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _httpClient?.Dispose();
+            _disposed = true;
+        }
+
+        private async Task<string> SendCompletionAsync(
+            IEnumerable<SharedChatMessage> messages,
+            float temperature,
+            int maxTokens,
+            IEnumerable<string>? stopSequences,
+            CancellationToken cancellationToken)
+        {
+            if (messages == null || !messages.Any())
+                throw new ArgumentException("Messages cannot be null or empty.", nameof(messages));
+
+            await EnsureInitializedAsync(cancellationToken);
+
+            var requestBody = new
+            {
+                model = ModelName,
+                messages = messages.Select(m => new { role = m.Role.ToLowerInvariant(), content = m.Content }),
+                temperature = Math.Clamp(temperature, 0f, 2f),
+                max_tokens = Math.Min(maxTokens, MaxTokens),
+                stop = stopSequences?.ToArray(),
+                stream = false
+            };
+
+            using var content = CreateJsonContent(requestBody);
+            var responseBody = await PostJsonAsync("/v1/chat/completions", content, cancellationToken);
+            return ParseCompletion(responseBody);
+        }
+
+        private StringContent CreateJsonContent(object value)
+        {
+            var json = JsonSerializer.Serialize(value, _jsonOptions);
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private async Task<string> PostJsonAsync(string path, HttpContent content, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var response = await _httpClient!.PostAsync(path, content, cancellationToken);
+                var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new InvalidOperationException(
+                        $"Sluice request failed with status {(int)response.StatusCode}: {responseBody}");
+                }
+
+                return responseBody;
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new InvalidOperationException("Failed to communicate with Sluice.", ex);
+            }
+        }
+
+        private static string ParseCompletion(string responseBody)
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("choices", out var choices) && choices.GetArrayLength() > 0)
+            {
+                var firstChoice = choices[0];
+                if (firstChoice.TryGetProperty("message", out var message) &&
+                    message.TryGetProperty("content", out var content))
+                {
+                    return content.GetString()?.Trim() ?? string.Empty;
+                }
+
+                if (firstChoice.TryGetProperty("text", out var text))
+                {
+                    return text.GetString()?.Trim() ?? string.Empty;
+                }
+            }
+
+            if (root.TryGetProperty("content", out var rootContent))
+                return rootContent.GetString()?.Trim() ?? string.Empty;
+
+            if (root.TryGetProperty("text", out var rootText))
+                return rootText.GetString()?.Trim() ?? string.Empty;
+
+            return responseBody;
+        }
+
+        private static float[][] ParseEmbeddings(string responseBody)
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            if (!doc.RootElement.TryGetProperty("data", out var data))
+                return [];
+
+            var embeddings = new List<float[]>();
+            foreach (var item in data.EnumerateArray())
+            {
+                if (!item.TryGetProperty("embedding", out var embedding))
+                    continue;
+
+                embeddings.Add(embedding.EnumerateArray().Select(e => e.GetSingle()).ToArray());
+            }
+
+            return embeddings.ToArray();
+        }
+
+        private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+        {
+            if (_httpClient == null)
+                await InitializeAsync(cancellationToken);
+        }
+
+        private sealed class SluiceChatSession : IChatSession
+        {
+            private readonly SluiceClient _owner;
+            private readonly List<ChatMessage> _history = new();
+
+            public SluiceChatSession(SluiceClient owner, string? systemMessage)
+            {
+                _owner = owner;
+                if (!string.IsNullOrWhiteSpace(systemMessage))
+                    _history.Add(new ChatMessage("system", systemMessage));
+            }
+
+            public IReadOnlyList<ChatMessage> History => _history.AsReadOnly();
+
+            public async Task<string> SendMessageAsync(string message, CancellationToken cancellationToken = default)
+            {
+                _history.Add(new ChatMessage("user", message));
+                var response = await _owner.GenerateChatCompletionAsync(_history, cancellationToken: cancellationToken);
+                _history.Add(new ChatMessage("assistant", response));
+                return response;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/ReasoningLayer/LLMReasoning/LLMClientFactory.cs
+++ b/src/ReasoningLayer/LLMReasoning/LLMClientFactory.cs
@@ -1,14 +1,44 @@
 using CognitiveMesh.ReasoningLayer.LLMReasoning.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace CognitiveMesh.ReasoningLayer.LLMReasoning
 {
     /// <summary>
     /// Factory class for creating ILLMClient instances.
-    /// Supports multi-provider routing: Azure OpenAI, OpenAI, MiniMax, DeepSeek,
-    /// Google, Anthropic, xAI, Meta (via Ollama), and any OpenAI-compatible endpoint.
+    /// Routes production model calls through Sluice by default. Direct provider
+    /// clients are retained only for explicit local mocks or migration shims.
     /// </summary>
     public static class LLMClientFactory
     {
+        private const string DirectProviderOverrideKey = "ALLOW_DIRECT_MODEL_PROVIDER";
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ILLMClient"/> using Sluice.
+        /// </summary>
+        /// <param name="baseUrl">The Sluice API base URL.</param>
+        /// <param name="apiKey">Optional Sluice bearer token or API key.</param>
+        /// <param name="modelName">The logical model or route name Sluice should resolve.</param>
+        /// <param name="maxTokens">Maximum output tokens.</param>
+        /// <param name="logger">Optional logger instance.</param>
+        /// <returns>An initialized ILLMClient instance.</returns>
+        public static async Task<ILLMClient> CreateSluiceClientAsync(
+            string baseUrl,
+            string apiKey = "",
+            string modelName = "default",
+            int maxTokens = 16_384,
+            ILogger? logger = null)
+        {
+            var client = new Implementations.SluiceClient(
+                baseUrl,
+                apiKey,
+                modelName,
+                maxTokens,
+                logger as ILogger<Implementations.SluiceClient>);
+
+            await client.InitializeAsync();
+            return client;
+        }
+
         /// <summary>
         /// Creates a new instance of ILLMClient using Azure OpenAI
         /// </summary>
@@ -27,6 +57,8 @@ namespace CognitiveMesh.ReasoningLayer.LLMReasoning
             int maxTokens = 8192,
             ILogger? logger = null)
         {
+            EnsureDirectProviderAllowed();
+
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new ArgumentException("API key is required", nameof(apiKey));
             if (string.IsNullOrWhiteSpace(endpoint))
@@ -62,6 +94,8 @@ namespace CognitiveMesh.ReasoningLayer.LLMReasoning
             string endpoint = "https://api.minimax.chat/v1",
             ILogger? logger = null)
         {
+            EnsureDirectProviderAllowed();
+
             var client = new Implementations.MiniMaxClient(
                 apiKey,
                 modelName,
@@ -90,6 +124,8 @@ namespace CognitiveMesh.ReasoningLayer.LLMReasoning
             int maxTokens = 16_384,
             ILogger? logger = null)
         {
+            EnsureDirectProviderAllowed();
+
             var client = new Implementations.OpenAICompatibleClient(
                 apiKey,
                 endpoint,
@@ -118,6 +154,8 @@ namespace CognitiveMesh.ReasoningLayer.LLMReasoning
             string? deploymentName = null,
             ILogger? logger = null)
         {
+            EnsureDirectProviderAllowed();
+
             var model = LLMModelRegistry.GetAllModels()
                 .FirstOrDefault(m => m.Key.Equals(modelKey, StringComparison.OrdinalIgnoreCase));
 
@@ -167,6 +205,31 @@ namespace CognitiveMesh.ReasoningLayer.LLMReasoning
             if (config == null)
                 throw new ArgumentNullException(nameof(config));
 
+            if (TryGetConfigValue(config, "SluiceBaseUrl", "SLUICE_BASE_URL", out var sluiceBaseUrl))
+            {
+                TryGetConfigValue(config, "SluiceApiKey", "SLUICE_API_KEY", out var sluiceApiKey);
+                TryGetConfigValue(config, "SluiceModel", "SLUICE_MODEL", "ModelKey", out var sluiceModel);
+                TryGetConfigValue(config, "MaxTokens", "SLUICE_MAX_TOKENS", out var sluiceMaxTokensValue);
+
+                var sluiceMaxTokens = 16_384;
+                if (!string.IsNullOrWhiteSpace(sluiceMaxTokensValue) &&
+                    !int.TryParse(sluiceMaxTokensValue, out sluiceMaxTokens))
+                {
+                    logger?.LogWarning("Invalid Sluice max tokens value '{MaxTokens}', using default {DefaultMaxTokens}",
+                        sluiceMaxTokensValue, sluiceMaxTokens);
+                    sluiceMaxTokens = 16_384;
+                }
+
+                return await CreateSluiceClientAsync(
+                    sluiceBaseUrl!,
+                    sluiceApiKey ?? string.Empty,
+                    string.IsNullOrWhiteSpace(sluiceModel) ? "default" : sluiceModel,
+                    sluiceMaxTokens,
+                    logger);
+            }
+
+            EnsureDirectProviderAllowed();
+
             // Check for new multi-provider config format
             if (config.TryGetValue("ModelKey", out var modelKey) && !string.IsNullOrWhiteSpace(modelKey))
             {
@@ -207,6 +270,49 @@ namespace CognitiveMesh.ReasoningLayer.LLMReasoning
                 modelName ?? "gpt-4",
                 maxTokens,
                 logger);
+        }
+
+        private static void EnsureDirectProviderAllowed()
+        {
+            var overrideValue = Environment.GetEnvironmentVariable(DirectProviderOverrideKey);
+            if (string.Equals(overrideValue, "true", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(overrideValue, "1", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(
+                "Direct model-provider clients are disabled. Configure SLUICE_BASE_URL, or set " +
+                $"{DirectProviderOverrideKey}=true only for local mocks or an explicit migration shim.");
+        }
+
+        private static bool TryGetConfigValue(
+            IReadOnlyDictionary<string, string> config,
+            string key,
+            string alternateKey,
+            out string? value)
+        {
+            return TryGetConfigValue(config, key, alternateKey, null, out value);
+        }
+
+        private static bool TryGetConfigValue(
+            IReadOnlyDictionary<string, string> config,
+            string key,
+            string alternateKey,
+            string? thirdKey,
+            out string? value)
+        {
+            if (config.TryGetValue(key, out value) && !string.IsNullOrWhiteSpace(value))
+                return true;
+
+            if (config.TryGetValue(alternateKey, out value) && !string.IsNullOrWhiteSpace(value))
+                return true;
+
+            if (thirdKey != null && config.TryGetValue(thirdKey, out value) && !string.IsNullOrWhiteSpace(value))
+                return true;
+
+            value = null;
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a Sluice-backed LLM client for reasoning-layer model operations
- add a protocol-level Sluice provider for agent orchestration completions and embeddings
- make LLMClientFactory prefer Sluice config and require ALLOW_DIRECT_MODEL_PROVIDER=true for direct provider shims
- replace shared env examples with Sluice settings and clarify OpenAI Terraform variables as exception-only

## Validation
- dotnet build CognitiveMesh.sln
- dotnet test CognitiveMesh.sln --no-build

## Notes
- Direct provider classes remain as explicit local/migration shims.
- Existing unrelated local change in src/UILayer/web/src/app/login/page.tsx was not included.