### PR TITLE
Route runtime model calls through Sluice

### DIFF
--- a/src/AgencyLayer/ToolIntegration/TextGenerationTool.cs
+++ b/src/AgencyLayer/ToolIntegration/TextGenerationTool.cs
@@ -1,30 +1,30 @@
 using Microsoft.Extensions.Logging;
-using OpenAI.Chat;
+using CognitiveMesh.Shared.Interfaces;
 
 namespace AgencyLayer.ToolIntegration
 {
     /// <summary>
-    /// A tool that generates text using Azure OpenAI's ChatClient (v2 stable API).
+    /// A tool that generates text using the configured LLM route.
     /// </summary>
     public class TextGenerationTool : BaseTool
     {
-        private readonly ChatClient _chatClient;
+        private readonly ILLMClient _llmClient;
 
         /// <inheritdoc />
         public override string Name => "Text Generation Tool";
 
         /// <inheritdoc />
-        public override string Description => "Generates text based on the provided prompt using Azure OpenAI.";
+        public override string Description => "Generates text based on the provided prompt using the configured LLM route.";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextGenerationTool"/> class.
         /// </summary>
-        /// <param name="chatClient">The OpenAI ChatClient used for completions.</param>
+        /// <param name="llmClient">The LLM client used for completions.</param>
         /// <param name="logger">The logger instance.</param>
-        public TextGenerationTool(ChatClient chatClient, ILogger<TextGenerationTool> logger)
+        public TextGenerationTool(ILLMClient llmClient, ILogger<TextGenerationTool> logger)
             : base(logger)
         {
-            _chatClient = chatClient ?? throw new ArgumentNullException(nameof(chatClient));
+            _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         }
 
         /// <summary>
@@ -49,12 +49,10 @@ namespace AgencyLayer.ToolIntegration
             {
                 var messages = new List<ChatMessage>
                 {
-                    new UserChatMessage(prompt)
+                    new("user", prompt)
                 };
 
-                ChatCompletion completion = await _chatClient.CompleteChatAsync(messages);
-
-                var result = completion.Content[0].Text;
+                var result = await _llmClient.GenerateChatCompletionAsync(messages);
 
                 _logger.LogInformation("Text generation executed successfully for prompt: {Prompt}", prompt);
 

--- a/src/AgencyLayer/ToolIntegration/ToolIntegration.csproj
+++ b/src/AgencyLayer/ToolIntegration/ToolIntegration.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\CognitiveMesh.Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/FoundationLayer/SemanticSearch/EnhancedRAGSystem.cs
+++ b/src/FoundationLayer/SemanticSearch/EnhancedRAGSystem.cs
@@ -1,14 +1,12 @@
 using System.Text;
-using Azure;
-using Azure.AI.OpenAI;
+using CognitiveMesh.Shared.Interfaces;
 using FoundationLayer.SemanticSearch.Ports;
-using OpenAI.Chat;
 
 namespace FoundationLayer.SemanticSearch;
 
 /// <summary>
 /// Provides an enhanced Retrieval-Augmented Generation (RAG) system that combines
-/// Azure AI Search vector indexing with OpenAI embeddings and completions.
+/// Azure AI Search vector indexing with routed embeddings and completions.
 /// Supports optional integration with Microsoft Fabric data endpoints and
 /// Azure Data Factory pipelines through the <see cref="IDataPipelinePort"/>.
 /// </summary>
@@ -16,10 +14,8 @@ public class EnhancedRAGSystem
 {
     private readonly SearchClient _searchClient;
     private readonly SearchIndexClient _indexClient;
-    private readonly AzureOpenAIClient _openAIClient;
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly string _indexName;
-    private readonly string _embeddingDeployment;
     private readonly IDataPipelinePort? _dataPipeline;
     private readonly ILogger<EnhancedRAGSystem>? _logger;
 
@@ -28,10 +24,8 @@ public class EnhancedRAGSystem
     /// </summary>
     /// <param name="searchClient">The Azure AI Search client for querying the index.</param>
     /// <param name="indexClient">The Azure AI Search index management client.</param>
-    /// <param name="openAIClient">The Azure OpenAI client for embeddings and completions.</param>
+    /// <param name="llmClient">The LLM client for routed embeddings and completions.</param>
     /// <param name="indexName">The name of the search index.</param>
-    /// <param name="embeddingDeployment">The OpenAI deployment name for generating embeddings.</param>
-    /// <param name="completionDeployment">The OpenAI deployment name for chat completions.</param>
     /// <param name="dataPipeline">
     /// Optional data pipeline port for Fabric and Data Factory integration.
     /// When null, pipeline operations are skipped gracefully.
@@ -40,19 +34,15 @@ public class EnhancedRAGSystem
     public EnhancedRAGSystem(
         SearchClient searchClient,
         SearchIndexClient indexClient,
-        AzureOpenAIClient openAIClient,
+        ILLMClient llmClient,
         string indexName,
-        string embeddingDeployment,
-        string completionDeployment,
         IDataPipelinePort? dataPipeline = null,
         ILogger<EnhancedRAGSystem>? logger = null)
     {
         _searchClient = searchClient;
         _indexClient = indexClient;
-        _openAIClient = openAIClient;
-        _chatClient = openAIClient.GetChatClient(completionDeployment);
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _indexName = indexName;
-        _embeddingDeployment = embeddingDeployment;
         _dataPipeline = dataPipeline;
         _logger = logger;
     }
@@ -114,11 +104,7 @@ public class EnhancedRAGSystem
     public async Task IndexDocumentAsync(KnowledgeDocument document)
     {
         // Generate embedding for document content
-        var embeddingResponse = await _openAIClient.GetEmbeddingsAsync(
-            _embeddingDeployment,
-            new EmbeddingsOptions(document.Content));
-
-        float[] embedding = embeddingResponse.Value.Data[0].Embedding.ToArray();
+        var embedding = await _llmClient.GetEmbeddingsAsync(document.Content);
 
         // Create search document
         var searchDocument = new Dictionary<string, object>
@@ -140,11 +126,7 @@ public class EnhancedRAGSystem
     public async Task<List<KnowledgeDocument>> SearchAsync(string query, int limit = 5, string filter = null)
     {
         // Generate embedding for query
-        var embeddingResponse = await _openAIClient.GetEmbeddingsAsync(
-            _embeddingDeployment,
-            new EmbeddingsOptions(query));
-
-        float[] queryEmbedding = embeddingResponse.Value.Data[0].Embedding.ToArray();
+        var queryEmbedding = await _llmClient.GetEmbeddingsAsync(query);
 
         // Create vector query
         var vectorQuery = new VectorizedQuery(queryEmbedding)
@@ -222,20 +204,11 @@ public class EnhancedRAGSystem
         // Create message list and completion options
         var messages = new List<ChatMessage>
         {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage($"Context:\n{context}\n\nQuestion: {query}")
+            new("system", systemPrompt),
+            new("user", $"Context:\n{context}\n\nQuestion: {query}")
         };
 
-        var chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = 0.3f,
-            MaxOutputTokenCount = 800
-        };
-
-        // Generate response
-        var completion = await _chatClient.CompleteChatAsync(messages, chatCompletionOptions);
-
-        return completion.Value.Content[0].Text;
+        return await _llmClient.GenerateChatCompletionAsync(messages, 0.3f, 800);
     }
 
     /// <summary>

--- a/src/MeshSimRuntime/Program.cs
+++ b/src/MeshSimRuntime/Program.cs
@@ -257,12 +257,23 @@ namespace CognitiveMesh.MeshSimRuntime
                 return new ContextTemplateResolver("templates", logger);
             });
 
-            // Add LLM provider (mock for now)
+            // Add LLM provider
             services.AddSingleton<ILLMProvider>(provider =>
             {
                 var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                var logger = loggerFactory.CreateLogger<MockLLMProvider>();
-                return new MockLLMProvider(logger);
+                var sluiceBaseUrl = Environment.GetEnvironmentVariable("SLUICE_BASE_URL");
+                if (!string.IsNullOrWhiteSpace(sluiceBaseUrl))
+                {
+                    var logger = loggerFactory.CreateLogger<SluiceLLMProvider>();
+                    return new SluiceLLMProvider(
+                        sluiceBaseUrl,
+                        Environment.GetEnvironmentVariable("SLUICE_API_KEY") ?? string.Empty,
+                        Environment.GetEnvironmentVariable("SLUICE_MODEL") ?? "default",
+                        logger);
+                }
+
+                var mockLogger = loggerFactory.CreateLogger<MockLLMProvider>();
+                return new MockLLMProvider(mockLogger);
             });
 
             // Add tool runner

--- a/src/MetacognitiveLayer/ContinuousLearning/ContinuousLearning.csproj
+++ b/src/MetacognitiveLayer/ContinuousLearning/ContinuousLearning.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Shared\CognitiveMesh.Shared.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\EnterpriseConnectors\EnterpriseConnectors.csproj" />
   </ItemGroup>
 

--- a/src/MetacognitiveLayer/ContinuousLearning/ContinuousLearningComponent.cs
+++ b/src/MetacognitiveLayer/ContinuousLearning/ContinuousLearningComponent.cs
@@ -1,11 +1,9 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using Azure;
-using Azure.AI.OpenAI;
+using CognitiveMesh.Shared.Interfaces;
 using FoundationLayer.EnterpriseConnectors;
 using MetacognitiveLayer.ContinuousLearning.Models;
 using Microsoft.Azure.Cosmos;
-using OpenAI.Chat;
 
 namespace MetacognitiveLayer.ContinuousLearning;
 
@@ -15,7 +13,7 @@ namespace MetacognitiveLayer.ContinuousLearning;
 /// </summary>
 public class ContinuousLearningComponent
 {
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly CosmosClient _cosmosClient;
     private readonly Container _learningDataContainer;
     private readonly FeatureFlagManager _featureFlagManager;
@@ -23,24 +21,19 @@ public class ContinuousLearningComponent
     /// <summary>
     /// Initializes a new instance of the <see cref="ContinuousLearningComponent"/> class.
     /// </summary>
-    /// <param name="openAIEndpoint">The Azure OpenAI endpoint URL.</param>
-    /// <param name="openAIApiKey">The Azure OpenAI API key.</param>
-    /// <param name="completionDeployment">The deployment name for chat completions.</param>
+    /// <param name="llmClient">The LLM client for routed insight generation.</param>
     /// <param name="cosmosConnectionString">The Cosmos DB connection string.</param>
     /// <param name="databaseName">The Cosmos DB database name.</param>
     /// <param name="containerName">The Cosmos DB container name for learning data.</param>
     /// <param name="featureFlagManager">The feature flag manager for checking enablement.</param>
     public ContinuousLearningComponent(
-        string openAIEndpoint,
-        string openAIApiKey,
-        string completionDeployment,
+        ILLMClient llmClient,
         string cosmosConnectionString,
         string databaseName,
         string containerName,
         FeatureFlagManager featureFlagManager)
     {
-        var aoaiClient = new AzureOpenAIClient(new Uri(openAIEndpoint), new AzureKeyCredential(openAIApiKey));
-        _chatClient = aoaiClient.GetChatClient(completionDeployment);
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _cosmosClient = new CosmosClient(cosmosConnectionString);
         _learningDataContainer = _cosmosClient.GetContainer(databaseName, containerName);
         _featureFlagManager = featureFlagManager;
@@ -216,17 +209,13 @@ public class ContinuousLearningComponent
                          "Generate 2-3 insights about performance improvements or degradations over time. " +
                          "For each insight, provide a title, description, and severity (High, Medium, Low).";
         
-        var completion = await _chatClient.CompleteChatAsync(
+        var insightsText = await _llmClient.GenerateChatCompletionAsync(
             [
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(userPrompt)
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
             ],
-            new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 1000
-            });
-        var insightsText = completion.Value.Content[0].Text;
+            0.3f,
+            1000);
 
         // Parse insights
         return ParseInsights(insightsText, "PerformanceTrend");
@@ -283,17 +272,13 @@ public class ContinuousLearningComponent
                          "Generate 2-3 insights about what factors correlate with positive or negative feedback. " +
                          "For each insight, provide a title, description, and severity (High, Medium, Low).";
         
-        var completion = await _chatClient.CompleteChatAsync(
+        var insightsText = await _llmClient.GenerateChatCompletionAsync(
             [
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(userPrompt)
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
             ],
-            new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 1000
-            });
-        var insightsText = completion.Value.Content[0].Text;
+            0.3f,
+            1000);
 
         // Parse insights
         return ParseInsights(insightsText, "FeedbackInsight");
@@ -345,17 +330,13 @@ public class ContinuousLearningComponent
                          "Generate 2-3 insights about specific areas that need enhancement. " +
                          "For each insight, provide a title, description, and severity (High, Medium, Low).";
         
-        var completion = await _chatClient.CompleteChatAsync(
+        var insightsText = await _llmClient.GenerateChatCompletionAsync(
             [
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(userPrompt)
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
             ],
-            new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 1000
-            });
-        var insightsText = completion.Value.Content[0].Text;
+            0.3f,
+            1000);
 
         // Parse insights
         return ParseInsights(insightsText, "ImprovementOpportunity");
@@ -416,17 +397,13 @@ public class ContinuousLearningComponent
                          "Focus on actionable changes to components, processes, or configurations. " +
                          "For each suggestion, provide a clear description of the change and its expected impact.";
         
-        var completion = await _chatClient.CompleteChatAsync(
+        var suggestionsText = await _llmClient.GenerateChatCompletionAsync(
             [
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(userPrompt)
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
             ],
-            new ChatCompletionOptions
-            {
-                Temperature = 0.4f,
-                MaxOutputTokenCount = 1200
-            });
-        var suggestionsText = completion.Value.Content[0].Text;
+            0.4f,
+            1200);
         
         // Parse suggestions
         return ParseSuggestions(suggestionsText);
@@ -491,17 +468,13 @@ public class ContinuousLearningComponent
                              "Provide a structured summary highlighting the key signal (positive/negative), " +
                              "the likely cause, and any actionable learning point.";
 
-            var completion = await _chatClient.CompleteChatAsync(
+            var summary = await _llmClient.GenerateChatCompletionAsync(
                 [
-                    new SystemChatMessage(systemPrompt),
-                    new UserChatMessage(userPrompt)
+                    new ChatMessage("system", systemPrompt),
+                    new ChatMessage("user", userPrompt)
                 ],
-                new ChatCompletionOptions
-                {
-                    Temperature = 0.2f,
-                    MaxOutputTokenCount = 300
-                });
-            var summary = completion.Value.Content[0].Text;
+                0.2f,
+                300);
 
             // Store the enriched feedback summary back to Cosmos DB for future retrieval
             var enrichedRecord = new
@@ -556,17 +529,13 @@ public class ContinuousLearningComponent
                              "Generate a brief learning signal (2-3 sentences) describing what went wrong " +
                              "and how the system should adjust.";
 
-            var completion = await _chatClient.CompleteChatAsync(
+            var learningSignal = await _llmClient.GenerateChatCompletionAsync(
                 [
-                    new SystemChatMessage(systemPrompt),
-                    new UserChatMessage(userPrompt)
+                    new ChatMessage("system", systemPrompt),
+                    new ChatMessage("user", userPrompt)
                 ],
-                new ChatCompletionOptions
-                {
-                    Temperature = 0.2f,
-                    MaxOutputTokenCount = 300
-                });
-            var learningSignal = completion.Value.Content[0].Text;
+                0.2f,
+                300);
 
             // Store the learning signal for future model adaptation cycles
             var signalRecord = new

--- a/src/MetacognitiveLayer/ContinuousLearning/LearningManager.cs
+++ b/src/MetacognitiveLayer/ContinuousLearning/LearningManager.cs
@@ -1,9 +1,7 @@
 using System.Collections.Concurrent;
-using Azure;
-using Azure.AI.OpenAI;
+using CognitiveMesh.Shared.Interfaces;
 using FoundationLayer.EnterpriseConnectors;
 using Microsoft.Extensions.Logging;
-using OpenAI.Chat;
 
 namespace MetacognitiveLayer.ContinuousLearning;
 
@@ -13,7 +11,7 @@ namespace MetacognitiveLayer.ContinuousLearning;
 /// </summary>
 public class LearningManager
 {
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly FeatureFlagManager _featureFlagManager;
     private readonly ILogger<LearningManager>? _logger;
 
@@ -81,20 +79,15 @@ public class LearningManager
     /// <summary>
     /// Initializes a new instance of the <see cref="LearningManager"/> class.
     /// </summary>
-    /// <param name="openAIEndpoint">The Azure OpenAI endpoint URL.</param>
-    /// <param name="openAIApiKey">The Azure OpenAI API key.</param>
-    /// <param name="completionDeployment">The deployment name for chat completions.</param>
+    /// <param name="llmClient">The LLM client for routed learning report generation.</param>
     /// <param name="featureFlagManager">The feature flag manager for checking enablement.</param>
     /// <param name="logger">Optional logger for structured logging.</param>
     public LearningManager(
-        string openAIEndpoint,
-        string openAIApiKey,
-        string completionDeployment,
+        ILLMClient llmClient,
         FeatureFlagManager featureFlagManager,
         ILogger<LearningManager>? logger = null)
     {
-        var aoaiClient = new AzureOpenAIClient(new Uri(openAIEndpoint), new AzureKeyCredential(openAIApiKey));
-        _chatClient = aoaiClient.GetChatClient(completionDeployment);
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _featureFlagManager = featureFlagManager ?? throw new ArgumentNullException(nameof(featureFlagManager));
         _logger = logger;
     }
@@ -157,18 +150,13 @@ public class LearningManager
         var systemPrompt = "You are a learning report generation system. Generate a detailed learning report based on the provided data.";
         var userPrompt = $"Generate a learning report based on the recent learning data. Currently enabled frameworks: {enabledList}. Total active: {_enabledFrameworks.Count}.";
 
-        var completion = await _chatClient.CompleteChatAsync(
+        return await _llmClient.GenerateChatCompletionAsync(
             [
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(userPrompt)
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
             ],
-            new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 800
-            });
-
-        return completion.Value.Content[0].Text;
+            0.3f,
+            800);
     }
 
     #endregion

--- a/src/MetacognitiveLayer/SelfEvaluation/MetacognitiveOversightComponent.cs
+++ b/src/MetacognitiveLayer/SelfEvaluation/MetacognitiveOversightComponent.cs
@@ -1,12 +1,10 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using Azure;
-using Azure.AI.OpenAI;
+using CognitiveMesh.Shared.Interfaces;
 using CognitiveMesh.ReasoningLayer.AnalyticalReasoning;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.Extensions.Logging;
-using OpenAI.Chat;
 
 namespace MetacognitiveLayer.SelfEvaluation;
 
@@ -17,27 +15,22 @@ namespace MetacognitiveLayer.SelfEvaluation;
 /// </summary>
 public class MetacognitiveOversightComponent
 {
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly TelemetryClient _telemetryClient;
     private readonly ILogger<MetacognitiveOversightComponent> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MetacognitiveOversightComponent"/> class.
     /// </summary>
-    /// <param name="openAIEndpoint">The Azure OpenAI endpoint URI.</param>
-    /// <param name="openAIApiKey">The Azure OpenAI API key.</param>
-    /// <param name="completionDeployment">The deployment name for chat completions.</param>
+    /// <param name="llmClient">The LLM client for routed evaluation calls.</param>
     /// <param name="telemetryClient">The Application Insights telemetry client.</param>
     /// <param name="logger">The logger instance.</param>
     public MetacognitiveOversightComponent(
-        string openAIEndpoint,
-        string openAIApiKey,
-        string completionDeployment,
+        ILLMClient llmClient,
         TelemetryClient telemetryClient,
         ILogger<MetacognitiveOversightComponent> logger)
     {
-        var aoaiClient = new AzureOpenAIClient(new Uri(openAIEndpoint), new AzureKeyCredential(openAIApiKey));
-        _chatClient = aoaiClient.GetChatClient(completionDeployment);
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _telemetryClient = telemetryClient;
         _logger = logger;
     }
@@ -142,20 +135,7 @@ public class MetacognitiveOversightComponent
                          "Provide a score from 0.0 (completely inaccurate) to 1.0 (completely accurate). " +
                          "Explain your reasoning and identify any factual errors or unsupported claims.";
 
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
-        };
-
-        var chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 1000
-        };
-
-        var completionResponse = await _chatClient.CompleteChatAsync(messages, chatCompletionOptions);
-        var evaluationText = completionResponse.Value.Content[0].Text;
+        var evaluationText = await CompleteEvaluationAsync(systemPrompt, userPrompt, 0.1f, 1000);
 
         // Extract score and explanation
         var score = ExtractScore(evaluationText);
@@ -196,20 +176,7 @@ public class MetacognitiveOversightComponent
                          "Provide a score from 0.0 (poor reasoning) to 1.0 (excellent reasoning). " +
                          "Consider logical coherence, consideration of multiple perspectives, and quality of inferences.";
 
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
-        };
-
-        var chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 1000
-        };
-
-        var completionResponse = await _chatClient.CompleteChatAsync(messages, chatCompletionOptions);
-        var evaluationText = completionResponse.Value.Content[0].Text;
+        var evaluationText = await CompleteEvaluationAsync(systemPrompt, userPrompt, 0.1f, 1000);
 
         // Extract score and explanation
         var score = ExtractScore(evaluationText);
@@ -234,20 +201,7 @@ public class MetacognitiveOversightComponent
                          "Provide a score from 0.0 (completely irrelevant) to 1.0 (perfectly relevant). " +
                          "Explain your reasoning and identify any irrelevant content.";
 
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
-        };
-
-        var chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 800
-        };
-
-        var completionResponse = await _chatClient.CompleteChatAsync(messages, chatCompletionOptions);
-        var evaluationText = completionResponse.Value.Content[0].Text;
+        var evaluationText = await CompleteEvaluationAsync(systemPrompt, userPrompt, 0.1f, 800);
 
         // Extract score and explanation
         var score = ExtractScore(evaluationText);
@@ -272,20 +226,7 @@ public class MetacognitiveOversightComponent
                          "Provide a score from 0.0 (very incomplete) to 1.0 (fully complete). " +
                          "Explain your reasoning and identify any missing elements.";
 
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
-        };
-
-        var chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = 0.1f,
-            MaxOutputTokenCount = 800
-        };
-
-        var completionResponse = await _chatClient.CompleteChatAsync(messages, chatCompletionOptions);
-        var evaluationText = completionResponse.Value.Content[0].Text;
+        var evaluationText = await CompleteEvaluationAsync(systemPrompt, userPrompt, 0.1f, 800);
 
         // Extract score and explanation
         var score = ExtractScore(evaluationText);
@@ -333,20 +274,7 @@ public class MetacognitiveOversightComponent
                          "Suggest 3-5 specific improvements that would address the weaknesses identified in the evaluations. " +
                          "Format each suggestion as a separate point.";
 
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
-        };
-
-        var chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = 0.3f,
-            MaxOutputTokenCount = 1000
-        };
-
-        var completionResponse = await _chatClient.CompleteChatAsync(messages, chatCompletionOptions);
-        var suggestionsText = completionResponse.Value.Content[0].Text;
+        var suggestionsText = await CompleteEvaluationAsync(systemPrompt, userPrompt, 0.3f, 1000);
 
         // Parse suggestions
         return ParseSuggestions(suggestionsText);
@@ -469,21 +397,24 @@ public class MetacognitiveOversightComponent
                          $"Perspective Analyses:\n{perspectivesText}\n\n" +
                          "Generate an improved response that addresses the suggestions while maintaining the core information.";
 
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
-        };
+        return await CompleteEvaluationAsync(systemPrompt, userPrompt, 0.3f, 1500, cancellationToken);
+    }
 
-        var chatCompletionOptions = new ChatCompletionOptions
-        {
-            Temperature = 0.3f,
-            MaxOutputTokenCount = 1500
-        };
-
-        var completionResponse = await _chatClient.CompleteChatAsync(messages, chatCompletionOptions);
-
-        return completionResponse.Value.Content[0].Text;
+    private Task<string> CompleteEvaluationAsync(
+        string systemPrompt,
+        string userPrompt,
+        float temperature,
+        int maxTokens,
+        CancellationToken cancellationToken = default)
+    {
+        return _llmClient.GenerateChatCompletionAsync(
+            [
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
+            ],
+            temperature,
+            maxTokens,
+            cancellationToken);
     }
 }
 

--- a/src/MetacognitiveLayer/SelfEvaluation/SelfEvaluation.csproj
+++ b/src/MetacognitiveLayer/SelfEvaluation/SelfEvaluation.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Shared\CognitiveMesh.Shared.csproj" />
     <ProjectReference Include="..\..\ReasoningLayer\AnalyticalReasoning\AnalyticalReasoning.csproj" />
   </ItemGroup>
 

--- a/src/ReasoningLayer/AnalyticalReasoning/AnalysisResultGenerator.cs
+++ b/src/ReasoningLayer/AnalyticalReasoning/AnalysisResultGenerator.cs
@@ -1,25 +1,23 @@
-using Azure.AI.OpenAI;
 using CognitiveMesh.ReasoningLayer.AnalyticalReasoning.Models;
-using OpenAI.Chat;
+using CognitiveMesh.Shared.Interfaces;
 
 namespace CognitiveMesh.ReasoningLayer.AnalyticalReasoning;
 
 /// <summary>
-/// Generates analytical results by invoking an OpenAI completion deployment
+/// Generates analytical results by invoking the configured LLM route
 /// with structured prompts for data-driven analysis.
 /// </summary>
 public class AnalysisResultGenerator
 {
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AnalysisResultGenerator"/> class.
     /// </summary>
-    /// <param name="openAIClient">The Azure OpenAI client for generating completions.</param>
-    /// <param name="completionDeployment">The deployment name to use for completions.</param>
-    public AnalysisResultGenerator(AzureOpenAIClient openAIClient, string completionDeployment)
+    /// <param name="llmClient">The LLM client for generating completions.</param>
+    public AnalysisResultGenerator(ILLMClient llmClient)
     {
-        _chatClient = openAIClient.GetChatClient(completionDeployment);
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
     }
 
     /// <summary>
@@ -30,21 +28,18 @@ public class AnalysisResultGenerator
         var systemPrompt = "You are an analytical system that performs data-driven analysis based on the provided query. " +
                            "Generate a detailed analysis report.";
 
-        var completion = await _chatClient.CompleteChatAsync(
+        var completion = await _llmClient.GenerateChatCompletionAsync(
             [
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage($"Data Query: {dataQuery}")
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", $"Data Query: {dataQuery}")
             ],
-            new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 800
-            });
+            0.3f,
+            800);
 
         return new AnalyticalResult
         {
             Query = dataQuery,
-            AnalysisReport = completion.Value.Content[0].Text
+            AnalysisReport = completion
         };
     }
 }

--- a/src/ReasoningLayer/AnalyticalReasoning/AnalyticalReasoning.csproj
+++ b/src/ReasoningLayer/AnalyticalReasoning/AnalyticalReasoning.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Shared\CognitiveMesh.Shared.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\Security\Security.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\FoundationLayer.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\EnterpriseConnectors\EnterpriseConnectors.csproj" />

--- a/src/ReasoningLayer/AnalyticalReasoning/MultiPerspectiveCognition.cs
+++ b/src/ReasoningLayer/AnalyticalReasoning/MultiPerspectiveCognition.cs
@@ -1,8 +1,6 @@
 using System.Text;
 using System.Text.Json;
-using Azure;
-using Azure.AI.OpenAI;
-using OpenAI.Chat;
+using CognitiveMesh.Shared.Interfaces;
 
 namespace CognitiveMesh.ReasoningLayer.AnalyticalReasoning;
 
@@ -12,7 +10,7 @@ namespace CognitiveMesh.ReasoningLayer.AnalyticalReasoning;
 /// </summary>
 public class MultiPerspectiveCognition
 {
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly Dictionary<string, string> _perspectiveEndpoints;
     private readonly HttpClient _httpClient;
 
@@ -20,13 +18,10 @@ public class MultiPerspectiveCognition
     /// Initializes a new instance of the <see cref="MultiPerspectiveCognition"/> class.
     /// </summary>
     public MultiPerspectiveCognition(
-        string openAIEndpoint,
-        string openAIApiKey,
-        string completionDeployment,
+        ILLMClient llmClient,
         Dictionary<string, string> perspectiveEndpoints)
     {
-        var aoaiClient = new AzureOpenAIClient(new Uri(openAIEndpoint), new AzureKeyCredential(openAIApiKey));
-        _chatClient = aoaiClient.GetChatClient(completionDeployment);
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _perspectiveEndpoints = perspectiveEndpoints;
         _httpClient = new HttpClient();
     }
@@ -87,21 +82,18 @@ public class MultiPerspectiveCognition
             // Use OpenAI with perspective-specific prompt
             var systemPrompt = GetSystemPromptForPerspective(perspective);
 
-            var completion = await _chatClient.CompleteChatAsync(
+            var analysis = await _llmClient.GenerateChatCompletionAsync(
                 [
-                    new SystemChatMessage(systemPrompt),
-                    new UserChatMessage(query)
+                    new ChatMessage("system", systemPrompt),
+                    new ChatMessage("user", query)
                 ],
-                new ChatCompletionOptions
-                {
-                    Temperature = 0.5f,
-                    MaxOutputTokenCount = 800
-                });
+                0.5f,
+                800);
 
             return new PerspectiveResult
             {
                 Perspective = perspective,
-                Analysis = completion.Value.Content[0].Text,
+                Analysis = analysis,
                 Confidence = 0.8 // Default confidence for OpenAI-generated perspectives
             };
         }
@@ -160,18 +152,13 @@ public class MultiPerspectiveCognition
 
         var userPrompt = $"Query: {query}\n\nPerspectives:\n{perspectivesText}\n\nPlease synthesize these perspectives into a coherent, integrated analysis.";
 
-        var completion = await _chatClient.CompleteChatAsync(
+        return await _llmClient.GenerateChatCompletionAsync(
             [
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(userPrompt)
+                new ChatMessage("system", systemPrompt),
+                new ChatMessage("user", userPrompt)
             ],
-            new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 1000
-            });
-
-        return completion.Value.Content[0].Text;
+            0.3f,
+            1000);
     }
 }
 

--- a/src/ReasoningLayer/DomainSpecificReasoning/DomainSpecificReasoner.cs
+++ b/src/ReasoningLayer/DomainSpecificReasoning/DomainSpecificReasoner.cs
@@ -1,4 +1,4 @@
-using OpenAI.Chat;
+using CognitiveMesh.Shared.Interfaces;
 
 namespace CognitiveMesh.ReasoningLayer.DomainSpecificReasoning;
 
@@ -26,7 +26,7 @@ public interface IDomainKnowledgePort
 public class DomainSpecificReasoner
 {
     private readonly TextAnalyticsClient _textAnalyticsClient;
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly ILogger<DomainSpecificReasoner> _logger;
     private readonly IDomainKnowledgePort _domainKnowledgePort;
 
@@ -34,18 +34,17 @@ public class DomainSpecificReasoner
     /// Initializes a new instance of the <see cref="DomainSpecificReasoner"/> class.
     /// </summary>
     /// <param name="textAnalyticsClient">The Azure Text Analytics client for key phrase extraction.</param>
-    /// <param name="openAIClient">The Azure OpenAI client for LLM-based reasoning.</param>
+    /// <param name="llmClient">The LLM client for routed model reasoning.</param>
     /// <param name="logger">The logger instance for structured logging.</param>
     /// <param name="domainKnowledgePort">The port for retrieving domain-specific knowledge.</param>
     public DomainSpecificReasoner(
         TextAnalyticsClient textAnalyticsClient,
-        AzureOpenAIClient openAIClient,
+        ILLMClient llmClient,
         ILogger<DomainSpecificReasoner> logger,
         IDomainKnowledgePort domainKnowledgePort)
     {
         _textAnalyticsClient = textAnalyticsClient ?? throw new ArgumentNullException(nameof(textAnalyticsClient));
-        ArgumentNullException.ThrowIfNull(openAIClient);
-        _chatClient = openAIClient.GetChatClient("text-davinci-003");
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _domainKnowledgePort = domainKnowledgePort ?? throw new ArgumentNullException(nameof(domainKnowledgePort));
     }
@@ -79,20 +78,14 @@ public class DomainSpecificReasoner
 
             var messages = new List<ChatMessage>
             {
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage($"Domain Knowledge:\n{domainKnowledge}\n\nQuestion: {input}")
+                new("system", systemPrompt),
+                new("user", $"Domain Knowledge:\n{domainKnowledge}\n\nQuestion: {input}")
             };
 
-            var options = new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 800
-            };
-
-            var completion = await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
+            var completion = await _llmClient.GenerateChatCompletionAsync(messages, 0.3f, 800, cancellationToken);
 
             _logger.LogInformation("Successfully applied specialized knowledge for domain: {Domain}", domain);
-            return completion.Value.Content[0].Text;
+            return completion;
         }
         catch (Exception ex)
         {

--- a/src/ReasoningLayer/EthicalReasoning/EthicalReasoner.cs
+++ b/src/ReasoningLayer/EthicalReasoning/EthicalReasoner.cs
@@ -1,4 +1,4 @@
-using OpenAI.Chat;
+using CognitiveMesh.Shared.Interfaces;
 
 namespace CognitiveMesh.ReasoningLayer.EthicalReasoning;
 
@@ -8,16 +8,15 @@ namespace CognitiveMesh.ReasoningLayer.EthicalReasoning;
 /// </summary>
 public class EthicalReasoner
 {
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly ILogger<EthicalReasoner> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EthicalReasoner"/> class.
     /// </summary>
-    public EthicalReasoner(string openAIEndpoint, string openAIApiKey, string completionDeployment, ILogger<EthicalReasoner> logger)
+    public EthicalReasoner(ILLMClient llmClient, ILogger<EthicalReasoner> logger)
     {
-        var aoaiClient = new AzureOpenAIClient(new Uri(openAIEndpoint), new AzureKeyCredential(openAIApiKey));
-        _chatClient = aoaiClient.GetChatClient(completionDeployment);
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _logger = logger;
     }
 
@@ -32,18 +31,11 @@ public class EthicalReasoner
 
             var messages = new List<ChatMessage>
             {
-                new SystemChatMessage(systemPrompt),
-                new UserChatMessage(input)
+                new("system", systemPrompt),
+                new("user", input)
             };
 
-            var options = new ChatCompletionOptions
-            {
-                Temperature = 0.3f,
-                MaxOutputTokenCount = 800
-            };
-
-            var completion = await _chatClient.CompleteChatAsync(messages, options);
-            return completion.Value.Content[0].Text;
+            return await _llmClient.GenerateChatCompletionAsync(messages, 0.3f, 800);
         }
         catch (Exception ex)
         {

--- a/src/ReasoningLayer/EthicalReasoning/EthicalReasoning.csproj
+++ b/src/ReasoningLayer/EthicalReasoning/EthicalReasoning.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="System.Text.Json"/>
     
     <!-- Project References -->
+    <ProjectReference Include="..\..\Shared\CognitiveMesh.Shared.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\Security\Security.csproj" />
   </ItemGroup>
 

--- a/src/ReasoningLayer/SystemsReasoning/SystemsReasoner.cs
+++ b/src/ReasoningLayer/SystemsReasoning/SystemsReasoner.cs
@@ -1,5 +1,5 @@
 using FoundationLayer.EnterpriseConnectors;
-using OpenAI.Chat;
+using CognitiveMesh.Shared.Interfaces;
 
 namespace CognitiveMesh.ReasoningLayer.SystemsReasoning;
 
@@ -11,21 +11,19 @@ namespace CognitiveMesh.ReasoningLayer.SystemsReasoning;
 public class SystemsReasoner
 {
     private readonly ILogger<SystemsReasoner> _logger;
-    private readonly ChatClient _chatClient;
+    private readonly ILLMClient _llmClient;
     private readonly FeatureFlagManager _featureFlagManager;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SystemsReasoner"/> class.
     /// </summary>
     /// <param name="logger">The logger instance for structured logging.</param>
-    /// <param name="openAIClient">The Azure OpenAI client for LLM-based analysis.</param>
-    /// <param name="completionDeployment">The deployment name for chat completions.</param>
+    /// <param name="llmClient">The LLM client for routed model analysis.</param>
     /// <param name="featureFlagManager">The feature flag manager for gating operations.</param>
-    public SystemsReasoner(ILogger<SystemsReasoner> logger, AzureOpenAIClient openAIClient, string completionDeployment, FeatureFlagManager featureFlagManager)
+    public SystemsReasoner(ILogger<SystemsReasoner> logger, ILLMClient llmClient, FeatureFlagManager featureFlagManager)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        ArgumentNullException.ThrowIfNull(openAIClient);
-        _chatClient = openAIClient.GetChatClient(completionDeployment ?? throw new ArgumentNullException(nameof(completionDeployment)));
+        _llmClient = llmClient ?? throw new ArgumentNullException(nameof(llmClient));
         _featureFlagManager = featureFlagManager ?? throw new ArgumentNullException(nameof(featureFlagManager));
     }
 
@@ -73,22 +71,16 @@ public class SystemsReasoner
 
         var messages = new List<ChatMessage>
         {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage($"System Description: {systemDescription}")
+            new("system", systemPrompt),
+            new("user", $"System Description: {systemDescription}")
         };
 
-        var options = new ChatCompletionOptions
-        {
-            Temperature = 0.3f,
-            MaxOutputTokenCount = 800
-        };
-
-        var completion = await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
+        var completion = await _llmClient.GenerateChatCompletionAsync(messages, 0.3f, 800, cancellationToken);
 
         return new SystemsAnalysisResult
         {
             SystemDescription = systemDescription,
-            AnalysisReport = completion.Value.Content[0].Text
+            AnalysisReport = completion
         };
     }
 
@@ -129,18 +121,11 @@ public class SystemsReasoner
 
                 var messages = new List<ChatMessage>
                 {
-                    new SystemChatMessage(dataDiscoveryPrompt),
-                    new UserChatMessage($"System Description: {systemDescription}")
+                    new("system", dataDiscoveryPrompt),
+                    new("user", $"System Description: {systemDescription}")
                 };
 
-                var options = new ChatCompletionOptions
-                {
-                    Temperature = 0.2f,
-                    MaxOutputTokenCount = 500
-                };
-
-                var completion = await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
-                enrichmentContext = completion.Value.Content[0].Text;
+                enrichmentContext = await _llmClient.GenerateChatCompletionAsync(messages, 0.2f, 500, cancellationToken);
                 endpointsConnected = 1; // Successfully queried the data discovery endpoint
             }
 
@@ -202,18 +187,11 @@ public class SystemsReasoner
 
                 var messages = new List<ChatMessage>
                 {
-                    new SystemChatMessage(pipelinePlanningPrompt),
-                    new UserChatMessage($"Pipeline Context: {pipelineContext}")
+                    new("system", pipelinePlanningPrompt),
+                    new("user", $"Pipeline Context: {pipelineContext}")
                 };
 
-                var options = new ChatCompletionOptions
-                {
-                    Temperature = 0.2f,
-                    MaxOutputTokenCount = 600
-                };
-
-                var completion = await _chatClient.CompleteChatAsync(messages, options, cancellationToken);
-                pipelinePlan = completion.Value.Content[0].Text;
+                pipelinePlan = await _llmClient.GenerateChatCompletionAsync(messages, 0.2f, 600, cancellationToken);
                 pipelinesTriggered = 1; // Successfully planned and triggered the pipeline
             }
 

--- a/src/ReasoningLayer/SystemsReasoning/SystemsReasoning.csproj
+++ b/src/ReasoningLayer/SystemsReasoning/SystemsReasoning.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Shared\CognitiveMesh.Shared.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\Security\Security.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\FoundationLayer.csproj" />
     <ProjectReference Include="..\..\FoundationLayer\EnterpriseConnectors\EnterpriseConnectors.csproj" />

--- a/tests/MetacognitiveLayer/ContinuousLearning/LearningManagerTests.cs
+++ b/tests/MetacognitiveLayer/ContinuousLearning/LearningManagerTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using CognitiveMesh.Shared.Interfaces;
 using FoundationLayer.EnterpriseConnectors;
 using MetacognitiveLayer.ContinuousLearning;
 using Microsoft.Extensions.Configuration;
@@ -15,10 +16,6 @@ namespace CognitiveMesh.Tests.MetacognitiveLayer.ContinuousLearning;
 /// </summary>
 public class LearningManagerTests
 {
-    private const string TestEndpoint = "https://test.openai.azure.com/";
-    private const string TestApiKey = "test-api-key-00000000000000000000";
-    private const string TestDeployment = "gpt-4-test";
-
     private readonly Mock<ILogger<LearningManager>> _loggerMock;
 
     /// <summary>
@@ -115,9 +112,7 @@ public class LearningManagerTests
     {
         var ffm = CreateFeatureFlagManager(flagOverrides);
         return new LearningManager(
-            TestEndpoint,
-            TestApiKey,
-            TestDeployment,
+            new FakeLLMClient(),
             ffm,
             logger);
     }
@@ -131,14 +126,43 @@ public class LearningManagerTests
     public void Constructor_NullFeatureFlagManager_ThrowsArgumentNullException()
     {
         var act = () => new LearningManager(
-            TestEndpoint,
-            TestApiKey,
-            TestDeployment,
+            new FakeLLMClient(),
             featureFlagManager: null!,
             logger: null);
 
         act.Should().Throw<ArgumentNullException>()
             .And.ParamName.Should().Be("featureFlagManager");
+    }
+
+    private sealed class FakeLLMClient : ILLMClient
+    {
+        public string ModelName => "fake";
+
+        public int MaxTokens => 4096;
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<string> GenerateCompletionAsync(
+            string prompt,
+            float temperature = 0.7f,
+            int maxTokens = 1000,
+            CancellationToken cancellationToken = default) => Task.FromResult("fake completion");
+
+        public Task<string> GenerateChatCompletionAsync(
+            IEnumerable<ChatMessage> messages,
+            float temperature = 0.7f,
+            int maxTokens = 1000,
+            CancellationToken cancellationToken = default) => Task.FromResult("fake chat completion");
+
+        public Task<float[]> GetEmbeddingsAsync(string text, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<float>());
+
+        public Task<float[][]> GetBatchEmbeddingsAsync(IEnumerable<string> texts, CancellationToken cancellationToken = default)
+            => Task.FromResult(Array.Empty<float[]>());
+
+        public void Dispose()
+        {
+        }
     }
 
     /// <summary>Tests that a valid constructor call succeeds.</summary>


### PR DESCRIPTION
## Summary
- wire MeshSimRuntime to use SluiceLLMProvider when SLUICE_BASE_URL is configured
- replace specialized direct ChatClient/AzureOpenAI usage with the shared ILLMClient port
- route RAG embeddings/completions, continuous learning, self-evaluation, and reasoning/tool components through Sluice-compatible client interfaces

## Verification
- dotnet build CognitiveMesh.sln
- dotnet test CognitiveMesh.sln --no-build
- rg scan now leaves direct provider references only in the explicit LLMReasoning legacy provider/factory shim