### PR TITLE
feat: make nist compliance widget live

### DIFF
--- a/src/UILayer/web/src/components/widgets/NistCompliance/NistComplianceDashboard.tsx
+++ b/src/UILayer/web/src/components/widgets/NistCompliance/NistComplianceDashboard.tsx
@@ -4,8 +4,13 @@ import React, { useState, useEffect, useCallback } from 'react';
 import MaturityGauge from './MaturityGauge';
 import GapAnalysisTable from './GapAnalysisTable';
 import ComplianceTimeline from './ComplianceTimeline';
-import { getNistScore, getNistRoadmap, getNistAuditLog } from '../api';
-import type { NISTScoreResponse, NISTRoadmapResponse, NISTAuditEntry } from '../types';
+import { getNistScore, getNistRoadmap, getNistAuditLog, getNistChecklist } from '../api';
+import type {
+  NISTScoreResponse,
+  NISTRoadmapResponse,
+  NISTAuditEntry,
+  NISTChecklistResponse,
+} from '../types';
 
 interface NistComplianceDashboardProps {
   organizationId?: string;
@@ -23,35 +28,62 @@ export default function NistComplianceDashboard({
   const [scoreData, setScoreData] = useState<NISTScoreResponse | null>(null);
   const [roadmapData, setRoadmapData] = useState<NISTRoadmapResponse | null>(null);
   const [auditEntries, setAuditEntries] = useState<NISTAuditEntry[]>([]);
+  const [checklistData, setChecklistData] = useState<NISTChecklistResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [endpointErrors, setEndpointErrors] = useState<string[]>([]);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
-    setError(null);
-    try {
-      const [score, roadmap, audit] = await Promise.all([
-        getNistScore(organizationId),
-        getNistRoadmap(organizationId),
-        getNistAuditLog(organizationId, 50),
-      ]);
-      setScoreData(score);
-      setRoadmapData(roadmap);
-      setAuditEntries(audit.entries ?? []);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Failed to load NIST compliance data.';
-      setError(msg);
-    } finally {
-      setLoading(false);
+    setEndpointErrors([]);
+
+    const results = await Promise.allSettled([
+      getNistScore(organizationId),
+      getNistRoadmap(organizationId),
+      getNistAuditLog(organizationId, 50),
+      getNistChecklist(organizationId),
+    ]);
+
+    const nextErrors: string[] = [];
+    const labels = ['score', 'roadmap', 'audit log', 'checklist'];
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        const reason = result.reason instanceof Error ? result.reason.message : 'request failed';
+        nextErrors.push(`${labels[index]}: ${reason}`);
+      }
+    });
+
+    const [scoreResult, roadmapResult, auditResult, checklistResult] = results;
+
+    if (scoreResult.status === 'fulfilled') {
+      setScoreData(scoreResult.value);
     }
+
+    if (roadmapResult.status === 'fulfilled') {
+      setRoadmapData(roadmapResult.value);
+    }
+
+    if (auditResult.status === 'fulfilled') {
+      setAuditEntries(auditResult.value.entries);
+    }
+
+    if (checklistResult.status === 'fulfilled') {
+      setChecklistData(checklistResult.value);
+    }
+
+    setEndpointErrors(nextErrors);
+    setLoading(false);
   }, [organizationId]);
 
   useEffect(() => {
-    void fetchData();
+    const refreshTimer = window.setTimeout(() => void fetchData(), 0);
+    return () => window.clearTimeout(refreshTimer);
   }, [fetchData]);
 
-  // Loading skeleton
-  if (loading) {
+  const hasAnyData = Boolean(scoreData || roadmapData || auditEntries.length > 0 || checklistData);
+  const failedCompletely = !loading && !hasAnyData && endpointErrors.length > 0;
+
+  if (loading && !hasAnyData) {
     return (
       <div className="space-y-4" aria-busy="true" aria-label="Loading NIST Compliance Dashboard">
         <div className="h-8 w-48 animate-pulse rounded bg-white/10" />
@@ -65,12 +97,11 @@ export default function NistComplianceDashboard({
     );
   }
 
-  // Error state
-  if (error) {
+  if (failedCompletely) {
     return (
       <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-6" role="alert">
         <h2 className="text-lg font-semibold text-red-400">Error loading compliance data</h2>
-        <p className="mt-1 text-sm text-red-300">{error}</p>
+        <p className="mt-1 text-sm text-red-300">{endpointErrors.join('; ')}</p>
         <button
           onClick={() => void fetchData()}
           className="mt-3 rounded bg-red-500/20 px-4 py-1.5 text-sm font-medium text-red-300 hover:bg-red-500/30"
@@ -82,9 +113,14 @@ export default function NistComplianceDashboard({
   }
 
   return (
-    <div className="space-y-6" role="region" aria-label="NIST Compliance Dashboard">
+    <div
+      className="space-y-6"
+      role="region"
+      aria-label="NIST Compliance Dashboard"
+      aria-busy={loading}
+    >
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-xl font-bold text-white">NIST AI RMF Compliance</h1>
           {scoreData && (
@@ -95,11 +131,44 @@ export default function NistComplianceDashboard({
         </div>
         <button
           onClick={() => void fetchData()}
-          className="rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-gray-300 hover:bg-white/15"
+          disabled={loading}
+          className="rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-gray-300 hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Refresh
+          {loading ? 'Refreshing...' : 'Refresh'}
         </button>
       </div>
+
+      {endpointErrors.length > 0 && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4" role="status">
+          <h2 className="text-sm font-semibold text-yellow-200">Some live compliance data did not load</h2>
+          <ul className="mt-2 list-inside list-disc space-y-1 text-xs text-yellow-100/90">
+            {endpointErrors.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {checklistData && (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+            <p className="text-xs uppercase text-gray-500">Checklist Progress</p>
+            <p className="mt-1 text-2xl font-semibold text-white">
+              {checklistData.completedStatements}/{checklistData.totalStatements}
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+            <p className="text-xs uppercase text-gray-500">Tracked Pillars</p>
+            <p className="mt-1 text-2xl font-semibold text-white">{checklistData.pillars.length}</p>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+            <p className="text-xs uppercase text-gray-500">Open Statements</p>
+            <p className="mt-1 text-2xl font-semibold text-white">
+              {Math.max(0, checklistData.totalStatements - checklistData.completedStatements)}
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Gauges row */}
       {scoreData && (

--- a/src/UILayer/web/src/components/widgets/api.ts
+++ b/src/UILayer/web/src/components/widgets/api.ts
@@ -48,20 +48,154 @@ import type {
   CognitiveDebtAssessment,
 } from './types';
 
+type ApiObject = Record<string, unknown>;
+
+function asObject(value: unknown): ApiObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as ApiObject : {};
+}
+
+function readValue(source: ApiObject, camelKey: string, pascalKey: string): unknown {
+  return source[camelKey] ?? source[pascalKey];
+}
+
+function readString(source: ApiObject, camelKey: string, pascalKey: string, fallback = ''): string {
+  const value = readValue(source, camelKey, pascalKey);
+  return typeof value === 'string' ? value : fallback;
+}
+
+function readNumber(source: ApiObject, camelKey: string, pascalKey: string, fallback = 0): number {
+  const value = readValue(source, camelKey, pascalKey);
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function readNullableNumber(source: ApiObject, camelKey: string, pascalKey: string): number | null {
+  const value = readValue(source, camelKey, pascalKey);
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function readBoolean(source: ApiObject, camelKey: string, pascalKey: string): boolean {
+  const value = readValue(source, camelKey, pascalKey);
+  return typeof value === 'boolean' ? value : false;
+}
+
+function readArray(source: ApiObject, camelKey: string, pascalKey: string): unknown[] {
+  const value = readValue(source, camelKey, pascalKey);
+  return Array.isArray(value) ? value : [];
+}
+
+function readDateString(source: ApiObject, camelKey: string, pascalKey: string): string {
+  const value = readValue(source, camelKey, pascalKey);
+  if (typeof value !== 'string') return new Date().toISOString();
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? new Date().toISOString() : value;
+}
+
+function normalizeNistScoreResponse(raw: unknown): NISTScoreResponse {
+  const source = asObject(raw);
+  return {
+    organizationId: readString(source, 'organizationId', 'OrganizationId'),
+    overallScore: readNumber(source, 'overallScore', 'OverallScore'),
+    pillarScores: readArray(source, 'pillarScores', 'PillarScores').map((item) => {
+      const pillar = asObject(item);
+      return {
+        pillarId: readString(pillar, 'pillarId', 'PillarId'),
+        pillarName: readString(pillar, 'pillarName', 'PillarName', 'Unlabeled pillar'),
+        averageScore: readNumber(pillar, 'averageScore', 'AverageScore'),
+        statementCount: readNumber(pillar, 'statementCount', 'StatementCount'),
+      };
+    }),
+    assessedAt: readDateString(source, 'assessedAt', 'AssessedAt'),
+  };
+}
+
+function normalizeNistRoadmapResponse(raw: unknown): NISTRoadmapResponse {
+  const source = asObject(raw);
+  return {
+    organizationId: readString(source, 'organizationId', 'OrganizationId'),
+    gaps: readArray(source, 'gaps', 'Gaps').map((item) => {
+      const gap = asObject(item);
+      return {
+        statementId: readString(gap, 'statementId', 'StatementId'),
+        currentScore: readNumber(gap, 'currentScore', 'CurrentScore'),
+        targetScore: readNumber(gap, 'targetScore', 'TargetScore'),
+        priority: readString(gap, 'priority', 'Priority', 'Unknown'),
+        recommendedActions: readArray(gap, 'recommendedActions', 'RecommendedActions')
+          .filter((action): action is string => typeof action === 'string'),
+      };
+    }),
+    generatedAt: readDateString(source, 'generatedAt', 'GeneratedAt'),
+  };
+}
+
+function normalizeNistChecklistResponse(raw: unknown): NISTChecklistResponse {
+  const source = asObject(raw);
+  return {
+    organizationId: readString(source, 'organizationId', 'OrganizationId'),
+    pillars: readArray(source, 'pillars', 'Pillars').map((item) => {
+      const pillar = asObject(item);
+      return {
+        pillarId: readString(pillar, 'pillarId', 'PillarId'),
+        pillarName: readString(pillar, 'pillarName', 'PillarName', 'Unlabeled pillar'),
+        statements: readArray(pillar, 'statements', 'Statements').map((statementItem) => {
+          const statement = asObject(statementItem);
+          return {
+            statementId: readString(statement, 'statementId', 'StatementId'),
+            description: readString(statement, 'description', 'Description'),
+            isComplete: readBoolean(statement, 'isComplete', 'IsComplete'),
+            evidenceCount: readNumber(statement, 'evidenceCount', 'EvidenceCount'),
+            currentScore: readNullableNumber(statement, 'currentScore', 'CurrentScore'),
+          };
+        }),
+      };
+    }),
+    totalStatements: readNumber(source, 'totalStatements', 'TotalStatements'),
+    completedStatements: readNumber(source, 'completedStatements', 'CompletedStatements'),
+  };
+}
+
+function normalizeNistAuditLogResponse(raw: unknown): NISTAuditLogResponse {
+  const source = asObject(raw);
+  return {
+    organizationId: readString(source, 'organizationId', 'OrganizationId'),
+    entries: readArray(source, 'entries', 'Entries').map((item) => {
+      const entry = asObject(item);
+      return {
+        entryId: readString(entry, 'entryId', 'EntryId'),
+        action: readString(entry, 'action', 'Action', 'UnknownAction'),
+        performedBy: readString(entry, 'performedBy', 'PerformedBy', 'Unknown'),
+        performedAt: readDateString(entry, 'performedAt', 'PerformedAt'),
+        details: readString(entry, 'details', 'Details'),
+      };
+    }),
+    totalCount: readNumber(source, 'totalCount', 'TotalCount'),
+  };
+}
+
+const liveReadOptions: RequestInit = { cache: 'no-store' };
+
 export async function getNistScore(organizationId: string): Promise<NISTScoreResponse> {
-  return fetchJson(`/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/score`);
+  const raw = await fetchJson<unknown>(`/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/score`, liveReadOptions);
+  return normalizeNistScoreResponse(raw);
 }
 
 export async function getNistRoadmap(organizationId: string): Promise<NISTRoadmapResponse> {
-  return fetchJson(`/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/roadmap`);
+  const raw = await fetchJson<unknown>(`/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/roadmap`, liveReadOptions);
+  return normalizeNistRoadmapResponse(raw);
 }
 
 export async function getNistChecklist(organizationId: string): Promise<NISTChecklistResponse> {
-  return fetchJson(`/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/checklist`);
+  const raw = await fetchJson<unknown>(`/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/checklist`, liveReadOptions);
+  return normalizeNistChecklistResponse(raw);
 }
 
 export async function getNistAuditLog(organizationId: string, maxResults = 50): Promise<NISTAuditLogResponse> {
-  return fetchJson(`/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/audit-log?maxResults=${maxResults}`);
+  const params = new URLSearchParams({ maxResults: Math.max(1, maxResults).toString() });
+  const raw = await fetchJson<unknown>(
+    `/api/v1/nist-compliance/organizations/${encodeURIComponent(organizationId)}/audit-log?${params.toString()}`,
+    liveReadOptions,
+  );
+  return normalizeNistAuditLogResponse(raw);
 }
 
 // ──────────────────────────── Adaptive Balance ──────────────────────────────

--- a/src/UILayer/web/src/components/widgets/types.ts
+++ b/src/UILayer/web/src/components/widgets/types.ts
@@ -41,9 +41,10 @@ export interface NISTRoadmapResponse {
 
 export interface NISTChecklistStatement {
   statementId: string;
-  text: string;
-  status: string;
+  description: string;
+  isComplete: boolean;
   evidenceCount: number;
+  currentScore: number | null;
 }
 
 export interface NISTChecklistPillar {
@@ -68,7 +69,9 @@ export interface NISTAuditEntry {
 }
 
 export interface NISTAuditLogResponse {
+  organizationId: string;
   entries: NISTAuditEntry[];
+  totalCount: number;
 }
 
 // ──────────────────────────── Adaptive Balance ──────────────────────────────


### PR DESCRIPTION
## Summary
- load NIST score, roadmap, audit-log, and checklist endpoints independently
- render checklist progress cards and keep partial data visible when a secondary endpoint fails
- normalize camelCase/PascalCase NIST ApiHost responses and align checklist/audit types with backend contracts

## Verification
- pnpm --dir src/UILayer/web exec eslint src/components/widgets/NistCompliance/NistComplianceDashboard.tsx src/components/widgets/api.ts src/components/widgets/types.ts
- pnpm --dir src/UILayer/web exec tsc --noEmit