### PR TITLE
feat: make impact metrics widget live

### DIFF
--- a/src/UILayer/web/src/components/widgets/ImpactMetrics/ImpactMetricsDashboard.tsx
+++ b/src/UILayer/web/src/components/widgets/ImpactMetrics/ImpactMetricsDashboard.tsx
@@ -1,79 +1,159 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import SafetyGauge from './SafetyGauge';
 import ImpactRadar from './ImpactRadar';
 import ImpactTimeline from './ImpactTimeline';
-import { getImpactReport, getResistancePatterns } from '../api';
-import type { ImpactReport, ResistanceIndicator } from '../types';
+import { getImpactReport, getImpactUsageSummary, getResistancePatterns, getSafetyScoreHistory } from '../api';
+import type { AdoptionTelemetry, ImpactReport, PsychologicalSafetyScore, ResistanceIndicator } from '../types';
 
 interface ImpactMetricsDashboardProps {
   tenantId?: string;
+  teamId?: string;
 }
 
-export default function ImpactMetricsDashboard({ tenantId = 'default-tenant' }: ImpactMetricsDashboardProps) {
+const DEFAULT_TENANT_ID = process.env.NEXT_PUBLIC_MYSTIRA_TENANT_ID ?? 'demo-tenant';
+const DEFAULT_TEAM_ID = process.env.NEXT_PUBLIC_IMPACT_METRICS_TEAM_ID ?? 'default-team';
+
+function formatDimensionLabel(value: string): string {
+  return value.replace(/([a-z])([A-Z])/g, '$1 $2').replace('AI', 'AI');
+}
+
+function toErrorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : 'Request failed.';
+}
+
+export default function ImpactMetricsDashboard({
+  tenantId = DEFAULT_TENANT_ID,
+  teamId = DEFAULT_TEAM_ID,
+}: ImpactMetricsDashboardProps) {
   const [report, setReport] = useState<ImpactReport | null>(null);
   const [resistance, setResistance] = useState<ResistanceIndicator[]>([]);
+  const [usage, setUsage] = useState<AdoptionTelemetry[]>([]);
+  const [safetyHistory, setSafetyHistory] = useState<PsychologicalSafetyScore[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
 
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const [rep, res] = await Promise.all([
-        getImpactReport(tenantId),
-        getResistancePatterns(tenantId),
-      ]);
-      setReport(rep);
-      setResistance(res);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load impact metrics.');
-    } finally {
-      setLoading(false);
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (isRefresh) {
+      setRefreshing(true);
+    } else {
+      setLoading(true);
     }
-  }, [tenantId]);
+    setError(null);
+    setWarnings([]);
 
-  useEffect(() => { void fetchData(); }, [fetchData]);
+    const [reportResult, resistanceResult, usageResult, safetyResult] = await Promise.allSettled([
+      getImpactReport(tenantId),
+      getResistancePatterns(tenantId),
+      getImpactUsageSummary(tenantId),
+      getSafetyScoreHistory(teamId, tenantId),
+    ]);
+
+    const nextWarnings: string[] = [];
+
+    if (reportResult.status === 'fulfilled') {
+      setReport(reportResult.value);
+    } else {
+      setError(`Impact report unavailable: ${toErrorMessage(reportResult.reason)}`);
+    }
+
+    if (resistanceResult.status === 'fulfilled') {
+      setResistance(resistanceResult.value);
+    } else {
+      nextWarnings.push(`Resistance patterns unavailable: ${toErrorMessage(resistanceResult.reason)}`);
+    }
+
+    if (usageResult.status === 'fulfilled') {
+      setUsage(usageResult.value);
+    } else {
+      nextWarnings.push(`Usage summary unavailable: ${toErrorMessage(usageResult.reason)}`);
+    }
+
+    if (safetyResult.status === 'fulfilled') {
+      setSafetyHistory(safetyResult.value);
+    } else {
+      nextWarnings.push(`Safety history unavailable: ${toErrorMessage(safetyResult.reason)}`);
+    }
+
+    setWarnings(nextWarnings);
+    setLoading(false);
+    setRefreshing(false);
+  }, [teamId, tenantId]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => void fetchData(), 0);
+    return () => window.clearTimeout(timeoutId);
+  }, [fetchData]);
+
+  const latestSafety = useMemo(
+    () => [...safetyHistory].sort((a, b) => Date.parse(b.calculatedAt) - Date.parse(a.calculatedAt))[0],
+    [safetyHistory],
+  );
+
+  const activeUsageCount = usage.filter((item) =>
+    item.action === 'FeatureUse' ||
+    item.action === 'WorkflowComplete' ||
+    item.action === 'Login'
+  ).length;
+
+  const radarLabels: string[] = [];
+  const radarValues: number[] = [];
+  if (latestSafety && Object.keys(latestSafety.dimensions).length > 0) {
+    for (const [label, value] of Object.entries(latestSafety.dimensions)) {
+      radarLabels.push(formatDimensionLabel(label));
+      radarValues.push(value);
+    }
+  } else if (report) {
+    radarLabels.push('Safety', 'Alignment', 'Adoption', 'Overall');
+    radarValues.push(report.safetyScore, report.alignmentScore * 100, report.adoptionRate * 100, report.overallImpactScore);
+  }
 
   if (loading) {
     return (
       <div className="space-y-4" aria-busy="true" aria-label="Loading Impact Metrics Dashboard">
         <div className="h-8 w-56 animate-pulse rounded bg-white/10" />
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          {[1, 2, 3].map((k) => <div key={k} className="h-40 animate-pulse rounded-lg bg-white/5" />)}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+          {[1, 2, 3, 4].map((k) => <div key={k} className="h-40 animate-pulse rounded-lg bg-white/5" />)}
         </div>
         <div className="h-64 animate-pulse rounded-lg bg-white/5" />
       </div>
     );
   }
 
-  if (error) {
+  if (error && !report) {
     return (
       <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-6" role="alert">
         <h2 className="text-lg font-semibold text-red-400">Error loading impact metrics</h2>
         <p className="mt-1 text-sm text-red-300">{error}</p>
-        <button onClick={() => void fetchData()} className="mt-3 rounded bg-red-500/20 px-4 py-1.5 text-sm font-medium text-red-300 hover:bg-red-500/30">Retry</button>
+        <p className="mt-2 text-xs text-red-200/80">Tenant: {tenantId}</p>
+        <button onClick={() => void fetchData(true)} className="mt-3 rounded bg-red-500/20 px-4 py-1.5 text-sm font-medium text-red-300 hover:bg-red-500/30">Retry</button>
       </div>
     );
   }
 
-  const radarLabels: string[] = [];
-  const radarValues: number[] = [];
-  if (report) {
-    radarLabels.push('Safety', 'Alignment', 'Adoption', 'Overall');
-    radarValues.push(report.safetyScore, report.alignmentScore * 100, report.adoptionRate * 100, report.overallImpactScore);
-  }
-
   return (
-    <div className="space-y-6" role="region" aria-label="Impact Metrics Dashboard">
-      <div className="flex items-center justify-between">
+    <div className="space-y-6" role="region" aria-label="Impact Metrics Dashboard" aria-busy={refreshing}>
+      <div className="flex items-center justify-between gap-4">
         <div>
           <h1 className="text-xl font-bold text-white">Impact Metrics</h1>
-          {report && <p className="text-xs text-gray-400">Report generated {new Date(report.generatedAt).toLocaleDateString()}</p>}
+          {report && <p className="text-xs text-gray-400">Report generated {new Date(report.generatedAt).toLocaleDateString()} for tenant {tenantId}</p>}
         </div>
-        <button onClick={() => void fetchData()} className="rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-gray-300 hover:bg-white/15">Refresh</button>
+        <button onClick={() => void fetchData(true)} className="rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-gray-300 hover:bg-white/15" disabled={refreshing}>
+          {refreshing ? 'Refreshing...' : 'Refresh'}
+        </button>
       </div>
+
+      {(error || warnings.length > 0) && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4" role="status">
+          {error && <p className="text-sm text-yellow-200">{error}</p>}
+          {warnings.map((warning) => (
+            <p key={warning} className="text-xs text-yellow-100/80">{warning}</p>
+          ))}
+        </div>
+      )}
 
       {report && (
         <>
@@ -95,9 +175,29 @@ export default function ImpactMetricsDashboard({ tenantId = 'default-tenant' }: 
             </div>
           </div>
 
-          <div className="rounded-lg border border-white/10 bg-white/5 p-4">
-            <h2 className="mb-3 text-sm font-semibold text-gray-300">Impact Dimensions</h2>
-            <ImpactRadar labels={radarLabels} values={radarValues} />
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(260px,1fr)]">
+            <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+              <h2 className="mb-3 text-sm font-semibold text-gray-300">Impact Dimensions</h2>
+              <ImpactRadar labels={radarLabels} values={radarValues} />
+            </div>
+
+            <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+              <h2 className="mb-3 text-sm font-semibold text-gray-300">Live API Signals</h2>
+              <dl className="space-y-3">
+                <div>
+                  <dt className="text-xs text-gray-500">Telemetry events</dt>
+                  <dd className="text-2xl font-semibold text-white">{usage.length}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Active-use events</dt>
+                  <dd className="text-2xl font-semibold text-white">{activeUsageCount}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Safety history points</dt>
+                  <dd className="text-2xl font-semibold text-white">{safetyHistory.length}</dd>
+                </div>
+              </dl>
+            </div>
           </div>
 
           {report.recommendations.length > 0 && (

--- a/src/UILayer/web/src/components/widgets/ImpactMetrics/ImpactTimeline.tsx
+++ b/src/UILayer/web/src/components/widgets/ImpactMetrics/ImpactTimeline.tsx
@@ -7,9 +7,15 @@ interface ImpactTimelineProps {
   indicators: ResistanceIndicator[];
 }
 
-function severityBadgeClass(severity: string): string {
-  if (severity === 'High') return 'bg-red-500/20 text-red-400';
-  if (severity === 'Medium') return 'bg-yellow-500/20 text-yellow-400';
+function severityLabel(severity: number): string {
+  if (severity >= 0.7) return 'High';
+  if (severity >= 0.35) return 'Medium';
+  return 'Low';
+}
+
+function severityBadgeClass(severity: number): string {
+  if (severity >= 0.7) return 'bg-red-500/20 text-red-400';
+  if (severity >= 0.35) return 'bg-yellow-500/20 text-yellow-400';
   return 'bg-gray-500/20 text-gray-400';
 }
 
@@ -20,14 +26,15 @@ export default function ImpactTimeline({ indicators }: ImpactTimelineProps) {
   return (
     <div className="space-y-3" role="list" aria-label="Resistance pattern timeline">
       {indicators.map((ind) => (
-        <div key={ind.indicatorId} className="flex items-start gap-3 rounded-lg border border-white/5 bg-white/[0.03] p-3" role="listitem">
+        <div key={`${ind.indicatorType}-${ind.firstDetectedAt}`} className="flex items-start gap-3 rounded-lg border border-white/5 bg-white/[0.03] p-3" role="listitem">
           <div className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-blue-500" />
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <span className="text-xs font-medium text-gray-300">{ind.pattern}</span>
-              <span className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold ${severityBadgeClass(ind.severity)}`}>{ind.severity}</span>
+              <span className="text-xs font-medium text-gray-300">{ind.indicatorType}</span>
+              <span className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold ${severityBadgeClass(ind.severity)}`}>{severityLabel(ind.severity)}</span>
             </div>
-            <p className="mt-0.5 text-xs text-gray-500">{ind.affectedUsers} affected users - {new Date(ind.detectedAt).toLocaleDateString()}</p>
+            <p className="mt-0.5 text-xs text-gray-400">{ind.description}</p>
+            <p className="mt-1 text-xs text-gray-500">{ind.affectedUserCount} affected users - {new Date(ind.firstDetectedAt).toLocaleDateString()}</p>
           </div>
         </div>
       ))}

--- a/src/UILayer/web/src/components/widgets/api.ts
+++ b/src/UILayer/web/src/components/widgets/api.ts
@@ -40,6 +40,7 @@ import type {
   ReflexionStatusResponse,
   ValueDiagnosticResponse,
   OrgBlindnessDetectionResponse,
+  AdoptionTelemetry,
   PsychologicalSafetyScore,
   ImpactReport,
   ResistanceIndicator,
@@ -262,6 +263,10 @@ export async function getImpactReport(
 
 export async function getResistancePatterns(tenantId: string): Promise<ResistanceIndicator[]> {
   return fetchJson(`/api/v1/impact-metrics/telemetry/${encodeURIComponent(tenantId)}/resistance`);
+}
+
+export async function getImpactUsageSummary(tenantId: string): Promise<AdoptionTelemetry[]> {
+  return fetchJson(`/api/v1/impact-metrics/telemetry/${encodeURIComponent(tenantId)}/summary`);
 }
 
 // ────────────────────────── Cognitive Sandwich ──────────────────────────────

--- a/src/UILayer/web/src/components/widgets/types.ts
+++ b/src/UILayer/web/src/components/widgets/types.ts
@@ -150,6 +150,26 @@ export interface PsychologicalSafetyScore {
   confidenceLevel: string;
 }
 
+export type AdoptionAction =
+  | 'Login'
+  | 'FeatureUse'
+  | 'FeatureIgnore'
+  | 'Feedback'
+  | 'Override'
+  | 'HelpRequest'
+  | 'WorkflowComplete';
+
+export interface AdoptionTelemetry {
+  telemetryId: string;
+  userId: string;
+  tenantId: string;
+  toolId: string;
+  action: AdoptionAction;
+  timestamp: string;
+  durationMs: number | null;
+  context: string | null;
+}
+
 export interface ImpactReport {
   reportId: string;
   tenantId: string;
@@ -164,11 +184,11 @@ export interface ImpactReport {
 }
 
 export interface ResistanceIndicator {
-  indicatorId: string;
-  pattern: string;
-  severity: string;
-  affectedUsers: number;
-  detectedAt: string;
+  indicatorType: string;
+  severity: number;
+  affectedUserCount: number;
+  firstDetectedAt: string;
+  description: string;
 }
 
 export interface ImpactAssessment {


### PR DESCRIPTION
## Summary
- wire Impact Metrics to live report, resistance, usage-summary, and safety-history API calls
- add partial warning states so secondary endpoint failures do not blank a valid report
- align resistance and adoption telemetry types with the backend contract

## Verification
- pnpm --dir src/UILayer/web exec eslint src/components/widgets/ImpactMetrics/ImpactMetricsDashboard.tsx src/components/widgets/ImpactMetrics/ImpactTimeline.tsx src/components/widgets/api.ts src/components/widgets/types.ts
- pnpm --dir src/UILayer/web exec tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live API signal metrics for telemetry events, active usage, and safety history.
  * Added dashboard refresh support and clearer loading states.
  * Added support for displaying partial data with warnings when some metrics are unavailable.
  * Added responsive dashboard layout and improved safety radar data.
  * Enhanced resistance indicators with severity labels, descriptions, affected-user counts, and detection dates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->