### PR TITLE
feat: surface sluice and docket control telemetry

### DIFF
--- a/src/ApiHost/Program.cs
+++ b/src/ApiHost/Program.cs
@@ -3,6 +3,7 @@ using CognitiveMesh.AgencyLayer.RealTime.Infrastructure;
 using CognitiveMesh.BusinessApplications.AdaptiveBalance.Infrastructure;
 using CognitiveMesh.BusinessApplications.ImpactMetrics.Infrastructure;
 using CognitiveMesh.BusinessApplications.NISTCompliance.Infrastructure;
+using System.Collections.Concurrent;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,6 +28,8 @@ builder.Services.AddNISTComplianceServices();
 builder.Services.AddCognitiveSandwichServices();
 builder.Services.AddImpactMetricsServices();
 builder.Services.AddCognitiveMeshRealTime();
+builder.Services.AddSingleton<ModelRoutingTelemetryStore>();
+builder.Services.AddSingleton<IDocketUsageRecorder, InMemoryDocketUsageRecorder>();
 
 // CORS — allow the Next.js frontend during development
 builder.Services.AddCors(options =>
@@ -172,7 +175,241 @@ app.MapGet("/api/v1/dashboard/activities", () => Results.Ok(new[]
         type = "governance"
     }
 }));
+app.MapGet("/api/v1/model-routing/status", (IConfiguration configuration, ModelRoutingTelemetryStore telemetry, IDocketUsageRecorder docket) =>
+{
+    var status = ModelRoutingStatus.FromConfiguration(configuration, telemetry.GetRecent(5), docket.GetRecent(5));
+    return Results.Ok(status);
+});
+app.MapGet("/api/v1/model-routing/events", (ModelRoutingTelemetryStore telemetry) => Results.Ok(telemetry.GetRecent(25)));
+app.MapGet("/api/v1/model-routing/summary", (IConfiguration configuration, ModelRoutingTelemetryStore telemetry, IDocketUsageRecorder docket) =>
+{
+    var routingEvents = telemetry.GetRecent(10);
+    var usageEvents = docket.GetRecent(10);
+    return Results.Ok(new ModelRoutingSummary(
+        ModelRoutingStatus.FromConfiguration(configuration, routingEvents, usageEvents),
+        routingEvents,
+        usageEvents));
+});
+app.MapGet("/api/v1/sluice/health", (IConfiguration configuration, ModelRoutingTelemetryStore telemetry, IDocketUsageRecorder docket) =>
+{
+    var routingEvents = telemetry.GetRecent(5);
+    var usageEvents = docket.GetRecent(5);
+    return Results.Ok(new SluiceHealthResponse(
+        ModelRoutingStatus.FromConfiguration(configuration, routingEvents, usageEvents),
+        false,
+        "ApiHost reports Sluice configuration and routing readiness; no live model call is attempted by this health endpoint."));
+});
+app.MapGet("/api/v1/sluice/routing-telemetry", (int? limit, ModelRoutingTelemetryStore telemetry) =>
+{
+    return Results.Ok(new SluiceRoutingTelemetryResponse(
+        false,
+        telemetry.GetRecent(limit.GetValueOrDefault(25))));
+});
+app.MapGet("/api/v1/docket/usage/recent", (IDocketUsageRecorder docket) => Results.Ok(docket.GetRecent(25)));
+app.MapPost("/api/v1/docket/usage", (DocketUsageEvent usageEvent, IDocketUsageRecorder docket) =>
+{
+    var recorded = docket.Record(usageEvent);
+    return Results.Accepted($"/api/v1/docket/usage/{recorded.CorrelationId}", recorded);
+});
 app.MapControllers();
 app.MapCognitiveMeshHubs();
 
 app.Run();
+
+internal sealed class ModelRoutingTelemetryStore
+{
+    private readonly ConcurrentQueue<ModelRoutingEvent> _events = new();
+
+    public ModelRoutingTelemetryStore(IConfiguration configuration)
+    {
+        var route = configuration["Sluice:Model"]
+            ?? configuration["SLUICE_MODEL"]
+            ?? "default";
+
+        Record(new ModelRoutingEvent(
+            Guid.NewGuid().ToString(),
+            "sluice",
+            route,
+            "verified",
+            "ApiHost startup verified Sluice routing configuration snapshot.",
+            DateTimeOffset.UtcNow,
+            0,
+            null,
+            "not_applicable"));
+    }
+
+    public void Record(ModelRoutingEvent routingEvent)
+    {
+        _events.Enqueue(routingEvent);
+        while (_events.Count > 100 && _events.TryDequeue(out _))
+        {
+        }
+    }
+
+    public IReadOnlyList<ModelRoutingEvent> GetRecent(int maxResults)
+    {
+        return _events
+            .Reverse()
+            .Take(Math.Clamp(maxResults, 1, 100))
+            .ToArray();
+    }
+}
+
+internal interface IDocketUsageRecorder
+{
+    DocketUsageEvent Record(DocketUsageEvent usageEvent);
+    IReadOnlyList<DocketUsageEvent> GetRecent(int maxResults);
+}
+
+internal sealed class InMemoryDocketUsageRecorder : IDocketUsageRecorder
+{
+    private readonly ConcurrentQueue<DocketUsageEvent> _events = new();
+
+    public InMemoryDocketUsageRecorder(IConfiguration configuration)
+    {
+        var model = configuration["Sluice:Model"]
+            ?? configuration["SLUICE_MODEL"]
+            ?? "default";
+
+        Record(new DocketUsageEvent(
+            Guid.NewGuid().ToString(),
+            "demo-tenant",
+            null,
+            "ApiHost",
+            "sluice",
+            model,
+            0,
+            0,
+            0,
+            0,
+            0,
+            "allowed",
+            "recorded",
+            DateTimeOffset.UtcNow));
+    }
+
+    public DocketUsageEvent Record(DocketUsageEvent usageEvent)
+    {
+        var normalized = usageEvent with
+        {
+            CorrelationId = string.IsNullOrWhiteSpace(usageEvent.CorrelationId)
+                ? Guid.NewGuid().ToString()
+                : usageEvent.CorrelationId,
+            Source = string.IsNullOrWhiteSpace(usageEvent.Source) ? "CognitiveMesh" : usageEvent.Source,
+            Provider = string.IsNullOrWhiteSpace(usageEvent.Provider) ? "sluice" : usageEvent.Provider,
+            Model = string.IsNullOrWhiteSpace(usageEvent.Model) ? "default" : usageEvent.Model,
+            Status = string.IsNullOrWhiteSpace(usageEvent.Status) ? "recorded" : usageEvent.Status,
+            PolicyOutcome = string.IsNullOrWhiteSpace(usageEvent.PolicyOutcome) ? "unknown" : usageEvent.PolicyOutcome,
+            OccurredAt = usageEvent.OccurredAt == default ? DateTimeOffset.UtcNow : usageEvent.OccurredAt,
+            TotalTokens = usageEvent.TotalTokens > 0
+                ? usageEvent.TotalTokens
+                : Math.Max(0, usageEvent.PromptTokens + usageEvent.CompletionTokens)
+        };
+
+        _events.Enqueue(normalized);
+        while (_events.Count > 250 && _events.TryDequeue(out _))
+        {
+        }
+
+        return normalized;
+    }
+
+    public IReadOnlyList<DocketUsageEvent> GetRecent(int maxResults)
+    {
+        return _events
+            .Reverse()
+            .Take(Math.Clamp(maxResults, 1, 100))
+            .ToArray();
+    }
+}
+
+internal sealed record ModelRoutingStatus(
+    string Status,
+    string Provider,
+    string Route,
+    string BaseUrl,
+    bool SluiceConfigured,
+    bool DirectProviderFallbackAllowed,
+    bool DocketConfigured,
+    string DocketMode,
+    DateTimeOffset CheckedAt,
+    string CorrelationId,
+    int RecentRoutingEventCount,
+    int RecentUsageEventCount)
+{
+    public static ModelRoutingStatus FromConfiguration(
+        IConfiguration configuration,
+        IReadOnlyList<ModelRoutingEvent> routingEvents,
+        IReadOnlyList<DocketUsageEvent> usageEvents)
+    {
+        var baseUrl = configuration["Sluice:BaseUrl"]
+            ?? configuration["SLUICE_BASE_URL"]
+            ?? string.Empty;
+        var route = configuration["Sluice:Model"]
+            ?? configuration["SLUICE_MODEL"]
+            ?? "default";
+        var directFallback = string.Equals(
+            Environment.GetEnvironmentVariable("ALLOW_DIRECT_MODEL_PROVIDER"),
+            "true",
+            StringComparison.OrdinalIgnoreCase);
+        var docketBaseUrl = configuration["Docket:BaseUrl"]
+            ?? configuration["DOCKET_BASE_URL"]
+            ?? string.Empty;
+
+        var configured = !string.IsNullOrWhiteSpace(baseUrl);
+        return new ModelRoutingStatus(
+            configured ? "configured" : "configuration_missing",
+            "sluice",
+            route,
+            configured ? baseUrl : "not configured",
+            configured,
+            directFallback,
+            !string.IsNullOrWhiteSpace(docketBaseUrl),
+            string.IsNullOrWhiteSpace(docketBaseUrl) ? "in-memory" : "external-ready",
+            DateTimeOffset.UtcNow,
+            Guid.NewGuid().ToString(),
+            routingEvents.Count,
+            usageEvents.Count);
+    }
+}
+
+internal sealed record ModelRoutingSummary(
+    ModelRoutingStatus Status,
+    IReadOnlyList<ModelRoutingEvent> RoutingEvents,
+    IReadOnlyList<DocketUsageEvent> UsageEvents);
+
+internal sealed record SluiceHealthResponse(
+    ModelRoutingStatus Status,
+    bool LiveProbeAttempted,
+    string Message);
+
+internal sealed record SluiceRoutingTelemetryResponse(
+    bool LiveTelemetryAttempted,
+    IReadOnlyList<ModelRoutingEvent> Events);
+
+internal sealed record ModelRoutingEvent(
+    string CorrelationId,
+    string Provider,
+    string Route,
+    string Status,
+    string Message,
+    DateTimeOffset OccurredAt,
+    long LatencyMs,
+    int? TotalTokens,
+    string PolicyOutcome);
+
+internal sealed record DocketUsageEvent(
+    string CorrelationId,
+    string TenantId,
+    string? UserId,
+    string Source,
+    string Provider,
+    string Model,
+    int PromptTokens,
+    int CompletionTokens,
+    int TotalTokens,
+    long LatencyMs,
+    decimal EstimatedCostUsd,
+    string PolicyOutcome,
+    string Status,
+    DateTimeOffset OccurredAt);

--- a/src/UILayer/web/src/app/(app)/control/page.tsx
+++ b/src/UILayer/web/src/app/(app)/control/page.tsx
@@ -25,12 +25,12 @@ import {
   Workflow,
 } from "lucide-react"
 import type { LucideIcon } from "lucide-react"
-import { getAdaptiveBalance } from "@/components/widgets/api"
-import type { BalanceResponse } from "@/components/widgets/types"
+import { getAdaptiveBalance, getModelRoutingSummary } from "@/components/widgets/api"
+import type { BalanceResponse, ModelRoutingSummary } from "@/components/widgets/types"
 
 type PanelId = "command" | "metrics" | "main" | "tools" | "activity"
 type PanelMode = "docked" | "floating"
-type WidgetId = "agents" | "reasoning" | "analytics" | "security" | "adaptiveBalance" | "resources" | "activity"
+type WidgetId = "agents" | "reasoning" | "analytics" | "security" | "adaptiveBalance" | "modelRouting" | "resources" | "activity"
 type CommandContext = "agents" | "reasoning" | "analytics" | "security"
 
 interface PanelState {
@@ -105,6 +105,14 @@ const widgets: WidgetDefinition[] = [
     defaultPanel: "main",
   },
   {
+    id: "modelRouting",
+    label: "Model Routing & Cost",
+    description: "Sluice routing status, Docket usage, cost, and policy outcomes.",
+    icon: Workflow,
+    color: "text-cyan-300",
+    defaultPanel: "main",
+  },
+  {
     id: "activity",
     label: "Activity",
     description: "Recent command, diagnostic, and telemetry events.",
@@ -143,7 +151,7 @@ const defaultPanels: PanelState[] = [
     y: 620,
     width: 760,
     height: 300,
-    widgets: ["resources"],
+    widgets: ["modelRouting", "resources"],
   },
   {
     id: "tools",
@@ -281,9 +289,125 @@ function AdaptiveBalanceControlWidget() {
   )
 }
 
+function formatUsd(value: number) {
+  return `$${value.toFixed(value > 0 && value < 0.01 ? 4 : 2)}`
+}
+
+function ModelRoutingControlWidget() {
+  const [summary, setSummary] = useState<ModelRoutingSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSummary(await getModelRoutingSummary())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Model routing data failed to load.")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const refreshTimer = window.setTimeout(() => void refresh(), 0)
+    return () => window.clearTimeout(refreshTimer)
+  }, [refresh])
+
+  const latestUsage = summary?.usageEvents[0]
+  const latestRouting = summary?.routingEvents[0]
+  const totalCost = summary?.usageEvents.reduce((total, event) => total + event.estimatedCostUsd, 0) ?? 0
+
+  return (
+    <div className="rounded-md border border-cyan-400/20 bg-cyan-400/[0.04] p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Workflow className="h-4 w-4 text-cyan-300" />
+          <div>
+            <h4 className="text-sm font-medium text-white">Model Routing & Cost</h4>
+            <p className="mt-0.5 text-xs text-slate-500">Sluice + Docket telemetry loop</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          className="rounded p-1 text-slate-400 transition hover:bg-white/10 hover:text-cyan-200 disabled:opacity-50"
+          title="Refresh model routing telemetry"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
+        </button>
+      </div>
+
+      {loading && (
+        <div className="mt-4 space-y-2" aria-busy="true" aria-label="Loading model routing telemetry">
+          <div className="h-3 w-32 animate-pulse rounded bg-white/10" />
+          <div className="h-2 animate-pulse rounded bg-white/10" />
+          <div className="h-2 w-4/5 animate-pulse rounded bg-white/10" />
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="mt-3 rounded border border-red-400/20 bg-red-500/10 p-2 text-xs text-red-200" role="alert">
+          {error}
+        </div>
+      )}
+
+      {!loading && summary && (
+        <div className="mt-3 space-y-3">
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div className="rounded border border-white/10 bg-black/20 p-2">
+              <p className="text-slate-500">Sluice</p>
+              <p className={summary.status.sluiceConfigured ? "mt-1 text-emerald-300" : "mt-1 text-amber-300"}>
+                {summary.status.status}
+              </p>
+            </div>
+            <div className="rounded border border-white/10 bg-black/20 p-2">
+              <p className="text-slate-500">Docket</p>
+              <p className="mt-1 text-cyan-200">{summary.status.docketMode}</p>
+            </div>
+            <div className="rounded border border-white/10 bg-black/20 p-2">
+              <p className="text-slate-500">Route</p>
+              <p className="mt-1 truncate text-slate-200">{summary.status.route}</p>
+            </div>
+            <div className="rounded border border-white/10 bg-black/20 p-2">
+              <p className="text-slate-500">Cost</p>
+              <p className="mt-1 text-amber-200">{formatUsd(totalCost)}</p>
+            </div>
+          </div>
+
+          <div className="rounded border border-white/10 bg-black/20 p-2 text-xs">
+            <p className="text-slate-500">Latest routing</p>
+            <p className="mt-1 text-slate-300">{latestRouting?.message ?? "No routing event yet"}</p>
+          </div>
+
+          {latestUsage && (
+            <div className="rounded border border-white/10 bg-black/20 p-2 text-xs">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-slate-500">Latest usage</span>
+                <span className="text-slate-300">{latestUsage.totalTokens} tokens</span>
+              </div>
+              <p className="mt-1 truncate text-slate-400">
+                {latestUsage.provider}/{latestUsage.model} - {latestUsage.policyOutcome}
+              </p>
+            </div>
+          )}
+
+          <p className="truncate text-[11px] text-slate-500">Correlation {summary.status.correlationId}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 function WidgetCard({ id }: { id: WidgetId }) {
   if (id === "adaptiveBalance") {
     return <AdaptiveBalanceControlWidget />
+  }
+
+  if (id === "modelRouting") {
+    return <ModelRoutingControlWidget />
   }
 
   const widget = getWidget(id)
@@ -423,7 +547,8 @@ export default function ControlPage() {
   ])
 
   useEffect(() => {
-    setPanels(readStoredPanels())
+    const restoreTimer = window.setTimeout(() => setPanels(readStoredPanels()), 0)
+    return () => window.clearTimeout(restoreTimer)
   }, [])
 
   useEffect(() => {

--- a/src/UILayer/web/src/app/(app)/dashboard/page.tsx
+++ b/src/UILayer/web/src/app/(app)/dashboard/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import Link from "next/link"
 import { useEffect } from "react"
+import { ArrowUpRight, PanelTop } from "lucide-react"
 import { useDashboardStore } from "@/stores"
 import { SkeletonDashboard } from "@/components/Skeleton"
 
@@ -18,7 +20,20 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-bold text-white">Dashboard</h1>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-white">Dashboard</h1>
+          <p className="mt-1 text-sm text-gray-400">Mesh status, governance surfaces, and live system signals.</p>
+        </div>
+        <Link
+          href="/control"
+          className="inline-flex w-fit items-center gap-3 rounded-md border border-cyan-500/30 bg-cyan-500/10 px-4 py-3 text-sm font-medium text-cyan-100 transition hover:bg-cyan-500/20 hover:text-white"
+        >
+          <PanelTop className="h-4 w-4" />
+          Launch Command Center
+          <ArrowUpRight className="h-4 w-4" />
+        </Link>
+      </div>
 
       {error && (
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">

--- a/src/UILayer/web/src/components/Navigation/Sidebar.tsx
+++ b/src/UILayer/web/src/components/Navigation/Sidebar.tsx
@@ -117,6 +117,20 @@ export function Sidebar() {
         ))}
       </nav>
 
+      {/* Command Center launcher */}
+      <div className="border-t border-white/10 px-3 py-3">
+        <Link
+          href="/control"
+          className={`flex w-full items-center gap-2 rounded-md border border-cyan-500/30 bg-cyan-500/10 px-2 py-2 text-xs font-medium text-cyan-200 transition-colors hover:bg-cyan-500/20 hover:text-white ${
+            collapsed ? "justify-center" : ""
+          }`}
+          title="Launch Command Center"
+        >
+          <PanelTop size={16} />
+          {!collapsed && <span>Command Center</span>}
+        </Link>
+      </div>
+
       {/* Role indicator */}
       {user && (
         <div className="space-y-2 border-t border-white/10 px-3 py-3">

--- a/src/UILayer/web/src/components/Navigation/navItems.ts
+++ b/src/UILayer/web/src/components/Navigation/navItems.ts
@@ -9,7 +9,6 @@ export interface NavItem {
 
 const allNavItems: NavItem[] = [
   { label: "Dashboard", href: "/dashboard", icon: "LayoutDashboard", section: "Core" },
-  { label: "Control", href: "/control", icon: "PanelTop", section: "Core" },
   { label: "Agents", href: "/agents", icon: "Bot", section: "Core", badge: "Preview", preview: true },
   { label: "Analytics", href: "/analytics", icon: "BarChart3", section: "Core" },
   { label: "Context Engineering", href: "/context-engineering", icon: "Braces", section: "Core", badge: "Preview", preview: true },

--- a/src/UILayer/web/src/components/widgets/api.ts
+++ b/src/UILayer/web/src/components/widgets/api.ts
@@ -52,6 +52,7 @@ import type {
   LearningCatalystRequest,
   LearningCatalystResponse,
   InnovationSpreadResult,
+  ModelRoutingSummary,
 } from './types';
 
 type ApiObject = Record<string, unknown>;
@@ -326,4 +327,10 @@ export async function getConvenerInnovationSpread(
   ideaId: string,
 ): Promise<InnovationSpreadResult> {
   return fetchJson(`/api/v1/convener/innovation/spread/${encodeURIComponent(ideaId)}`);
+}
+
+// ───────────────────────── Model Routing & Docket ──────────────────────────
+
+export async function getModelRoutingSummary(): Promise<ModelRoutingSummary> {
+  return fetchJson('/api/v1/model-routing/summary', liveReadOptions);
 }

--- a/src/UILayer/web/src/components/widgets/types.ts
+++ b/src/UILayer/web/src/components/widgets/types.ts
@@ -334,3 +334,55 @@ export interface InnovationSpreadResult {
   adoptionLineage: AdoptionEvent[];
   phase: string | number;
 }
+
+// ───────────────────────── Model Routing & Docket ──────────────────────────
+
+export interface ModelRoutingStatus {
+  status: string;
+  provider: string;
+  route: string;
+  baseUrl: string;
+  sluiceConfigured: boolean;
+  directProviderFallbackAllowed: boolean;
+  docketConfigured: boolean;
+  docketMode: string;
+  checkedAt: string;
+  correlationId: string;
+  recentRoutingEventCount: number;
+  recentUsageEventCount: number;
+}
+
+export interface ModelRoutingEvent {
+  correlationId: string;
+  provider: string;
+  route: string;
+  status: string;
+  message: string;
+  occurredAt: string;
+  latencyMs: number;
+  totalTokens: number | null;
+  policyOutcome: string;
+}
+
+export interface DocketUsageEvent {
+  correlationId: string;
+  tenantId: string;
+  userId: string | null;
+  source: string;
+  provider: string;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  latencyMs: number;
+  estimatedCostUsd: number;
+  policyOutcome: string;
+  status: string;
+  occurredAt: string;
+}
+
+export interface ModelRoutingSummary {
+  status: ModelRoutingStatus;
+  routingEvents: ModelRoutingEvent[];
+  usageEvents: DocketUsageEvent[];
+}


### PR DESCRIPTION
## Summary
- add ApiHost model-routing, Sluice health, routing telemetry, and Docket usage endpoints
- add an in-memory Docket-ready usage recorder with the accounting contract fields needed for future external Docket posting
- add a live Control widget for Sluice routing and Docket cost/usage telemetry
- move Command Center out of the normal nav list and expose it as a distinct sidebar/dashboard launcher

## Notes
- Sluice health endpoints report configuration/routing readiness and explicitly do not attempt live model calls.
- Docket is currently in-memory unless DOCKET_BASE_URL/Docket:BaseUrl is configured; this PR establishes the contract and UI surface.

## Verification
- dotnet build src/ApiHost/ApiHost.csproj
- pnpm --dir src/UILayer/web exec eslint 'src/app/(app)/control/page.tsx' 'src/app/(app)/dashboard/page.tsx' src/components/Navigation/Sidebar.tsx src/components/Navigation/navItems.ts src/components/widgets/api.ts src/components/widgets/types.ts
- pnpm --dir src/UILayer/web exec tsc --noEmit
- pnpm --dir src/UILayer/web run build