### PR TITLE
docs: refresh cognitive mesh migration package

### DIFF
--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -1,22 +1,59 @@
 # Cognitive Mesh NeuralLiquid Handoff
 
-Last updated: 2026-07-12
+Last updated: 2026-07-13
 
 ## Current State
 
 - Repository: `phoenixvc/cognitive-mesh`
 - Branch: `dev`
-- Latest pushed commit: `89ab306 feat: add mystira identity login`
+- Latest deployed/frontend merge commit verified this session: `5b76bf34389b0a82dcc546c2eb09d0494cb09e1e`
+- Latest deployed API/frontend integration commit from Sluice/Docket work: `6e1e8fc991f73bee2e6a8fe017fa8b917cfaad87`
 - Prod Azure resource group: `nl-prod-cognitive-mesh-rg`
 - Shared ACR: `myssharedacr.azurecr.io`
 - API App Service: `cognitive-mesh-api-prod`
 - Frontend App Service: `cognitive-mesh-frontend-prod`
-- Frontend deploy run `29195268245` completed successfully through staging and production.
-- API deploy run `29193880939` completed successfully through staging and production.
+- API image verified after integration deploy: `myssharedacr.azurecr.io/cognitive-mesh-api:sha-6e1e8fc`
+- Frontend image verified after widget-library deploy: `myssharedacr.azurecr.io/cognitive-mesh-frontend:sha-5b76bf3`
+- API deploy run `29208727764` completed successfully.
+- Frontend deploy run `29208730754` completed successfully for Sluice/Docket and IA work.
+- Frontend deploy run `29211117975` completed successfully for the widget-library fix.
+
+## Session Summary
+
+Merged and deployed Cognitive Mesh Control/Command Center follow-up work:
+
+- PR #506: Adaptive Balance live Control widget.
+- PR #507: NIST/Compliance live widget.
+- PR #508: Impact Metrics live widget.
+- PR #509: Convener endpoint wiring.
+- PR #510: Sluice health/routing telemetry, Docket usage-event adapter, Model Routing & Cost Control widget, and Command Center IA cleanup.
+- PR #511: fixed Command Center Widget Library so widgets can be placed, moved, removed, and persisted in browser layout state.
+
+Production checks completed:
+
+- `https://api.cognitivemesh.neuralliquid.ai/api/v1/model-routing/summary` returned `200`.
+- `https://api.cognitivemesh.neuralliquid.ai/api/v1/sluice/health` returned `200`.
+- `https://api.cognitivemesh.neuralliquid.ai/api/v1/docket/usage/recent` returned `200`.
+- `https://cognitive-mesh.neuralliquid.ai/control` returned protected-route redirect to `/login?returnTo=%2Fcontrol`.
+- `https://cognitive-mesh-frontend-prod.azurewebsites.net/control` returned protected-route redirect to `/login?returnTo=%2Fcontrol`.
+- `https://cognitive-mesh-frontend-prod.azurewebsites.net/api/health` returned healthy after frontend deploy.
+
+Verification run locally before PRs:
+
+- `dotnet build src/ApiHost/ApiHost.csproj`
+- focused frontend ESLint for changed Control/dashboard/navigation/widget files
+- `pnpm --dir src/UILayer/web exec tsc --noEmit`
+- `pnpm --dir src/UILayer/web run build`
+
+Known non-blocking warnings:
+
+- Style Dictionary reports existing token collisions.
+- Next config still contains deprecated/unsupported `eslint` config.
+- Next reports the `middleware` file convention should move to `proxy`.
 
 ## First Task Before Org Migration
 
-Route all Cognitive Mesh AI/model calls through Sluice before continuing the org migration.
+Route all Cognitive Mesh AI/model calls through Sluice before continuing the org migration. The first production-facing Sluice/Docket status contracts are now live, but real external Sluice/Docket connectivity still needs configuration and auth.
 
 Rationale:
 
@@ -26,8 +63,8 @@ Rationale:
 
 Initial implementation menu:
 
-1. Add a Sluice client/adapter in CogMesh behind a stable port/interface.
-2. Introduce deployment config such as `SLUICE_BASE_URL` and the chosen auth mechanism for CogMesh-to-Sluice calls.
+1. Configure `SLUICE_BASE_URL` and chosen CogMesh-to-Sluice auth in production.
+2. Configure `DOCKET_BASE_URL` and chosen CogMesh-to-Docket auth in production.
 3. Replace concrete direct model calls with the Sluice adapter.
 4. Keep `enable_openai = false` for CogMesh prod infrastructure unless a deliberate exception is approved.
 5. Remove or quarantine direct provider secrets from CogMesh deployment and docs once Sluice is wired.
@@ -51,6 +88,8 @@ Known direct-AI areas to inspect first:
   - `https://cognitive-mesh-frontend-prod.azurewebsites.net/login`
   - `https://cognitive-mesh-frontend-prod-staging.azurewebsites.net/login`
   - `https://cognitivemesh.neuralliquid.ai/login`
+  - `https://cognitive-mesh.neuralliquid.ai/login`
+  - `https://control.cognitive-mesh.neuralliquid.ai/login`
   - `https://app.cognitivemesh.neuralliquid.ai/login`
   - `https://frontend.cognitivemesh.neuralliquid.ai/login`
   - `https://staging.cognitivemesh.neuralliquid.ai/login`
@@ -68,6 +107,52 @@ Verified after deploy/apply:
 - API prod health: `https://cognitive-mesh-api-prod.azurewebsites.net/healthz`
 - API staging health: `https://cognitive-mesh-api-prod-staging.azurewebsites.net/healthz`
 
+Additional notes:
+
+- `control.cognitive-mesh.neuralliquid.ai` is bound on the frontend App Service, but `curl` to `https://control.cognitive-mesh.neuralliquid.ai/control` timed out from the CLI environment after the latest deploy. The same route worked on the main host and Azure default host, and the workflow production health check passed. Follow up with browser check plus DNS/custom-domain/proxy inspection if the subdomain still hangs.
+- The Control/Command Center page is protected by login and reachable at `/control`.
+- Control is intentionally removed from normal sidebar navigation and exposed through the Command Center launcher/dashboard entry.
+
+## Command Center Status
+
+Delivered:
+
+- Fullscreen Command Center title and return-to-mesh button.
+- Normal sidebar no longer treats Control as a peer dashboard page.
+- Command Center launcher added near the signed-in user area.
+- Widget Library now supports choosing a destination panel and adding/moving/removing widgets.
+- Layout state persists in browser `localStorage`.
+- Live widgets currently include Adaptive Balance and Model Routing & Cost.
+
+Still planned:
+
+- Server-backed user layout persistence.
+- Replace remaining preview widgets with live modules.
+- Decide whether `control.cognitive-mesh.neuralliquid.ai` should route directly to `/control` instead of requiring `/control`.
+- Improve mobile layout of the Command Center after the core desktop interaction stabilizes.
+
+## Sluice/Docket Status
+
+Delivered:
+
+- `GET /api/v1/model-routing/status`
+- `GET /api/v1/model-routing/events`
+- `GET /api/v1/model-routing/summary`
+- `GET /api/v1/sluice/health`
+- `GET /api/v1/sluice/routing-telemetry`
+- `GET /api/v1/docket/usage/recent`
+- `POST /api/v1/docket/usage`
+- Control widget reads `/api/v1/model-routing/summary`.
+
+Current production behavior:
+
+- Sluice reports `configuration_missing` until `SLUICE_BASE_URL` is set.
+- Azure metadata confirms the Sluice LiteLLM gateway custom domain is `https://litellm.sluice.phoenixvc.tech`; CogMesh prod Terraform now has a non-secret hook for `SLUICE_BASE_URL`.
+- Docket reports `in-memory` until `DOCKET_BASE_URL` is set.
+- Docket canonical API URL is now live at `https://docket.phoenixvc.tech`.
+- Do not set `DOCKET_BASE_URL` until CogMesh-to-Docket auth and the production ingestion contract are confirmed. The current canonical host fronts the existing `pvc-shared-costops-api` Container App while Docket naming and IaC catch up.
+- The Sluice health endpoint does not perform a live model call; it reports configuration/routing readiness and `liveProbeAttempted=false`.
+
 ## Org Migration Tasks After Sluice Routing
 
 1. Decide final target org/repo names and update GitHub Actions OIDC federated credentials.
@@ -78,3 +163,81 @@ Verified after deploy/apply:
 4. Bind custom domains and certificates for the chosen `*.cognitivemesh.neuralliquid.ai` hosts.
 5. Run final frontend/API deploys from the target org after OIDC and secrets are confirmed.
 
+## Handoff - 2026-07-13 Sluice/Docket Migration Prep
+
+```yaml
+status: partial
+migration_batch: "Phase 1 / Batch 1 pre-transfer; Sluice routing prep before org transfer"
+work_completed:
+  - Added standalone migration artifacts required by the Baton plan:
+      - docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
+      - docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
+      - docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+  - Added Terraform hooks for Cognitive Mesh API routing settings:
+      - ALLOW_DIRECT_MODEL_PROVIDER=false
+      - SLUICE_BASE_URL
+      - SLUICE_MODEL
+      - SLUICE_MAX_TOKENS
+      - optional DOCKET_BASE_URL
+  - Set prod Sluice base URL to the verified LiteLLM gateway:
+      - https://litellm.sluice.phoenixvc.tech
+  - Left DOCKET_BASE_URL empty because shared-costops has been renamed to Docket and the canonical Docket service is not yet live.
+  - Updated manifest and this handoff with the Docket blocker.
+  - Configured canonical Docket API hostname:
+      - docket.phoenixvc.tech CNAME -> pvc-shared-costops-api.ashymushroom-1f7d8121.southafricanorth.azurecontainerapps.io
+      - asuid.docket.phoenixvc.tech TXT -> Container App custom-domain verification ID
+      - Azure managed certificate mc-pvc-shared-cos-docket-phoenixvc-0990 bound with SNI
+evidence:
+  - Azure Container App metadata confirms pvc-prod-sluice-ca has custom domain litellm.sluice.phoenixvc.tech.
+  - DNS resolves for litellm.sluice.phoenixvc.tech and sluice.phoenixvc.tech.
+  - Azure Container App metadata shows old pvc-shared-costops-api with no custom domain returned.
+  - Local docket checkout still has generated pvc-costops-analytics naming and old pvc-shared-costops Azure resource names.
+  - https://docket.phoenixvc.tech/health returned {"status":"ok","backend":"table"}.
+  - https://docket.phoenixvc.tech/config/status returned backend=table and auth_disabled=false.
+  - Azure Container App hostname list shows docket.phoenixvc.tech bound with SniEnabled.
+files_changed:
+  - docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+  - docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
+  - docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
+  - docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
+  - docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+  - infra/environments/prod/terragrunt.hcl
+  - infra/main.tf
+  - infra/modules/webapp-container/main.tf
+  - infra/modules/webapp-container/variables.tf
+  - infra/variables.tf
+tickets_updated:
+  - Baton CogMesh migration task 01a8c263-9a33-463c-9041-92109cbe9f6d logged with current status.
+  - Created Docket blocker task e93d06b5-3ef6-4a4a-9692-9f1825022c81.
+  - Related Docket task as blocking the CogMesh migration task.
+tests_run:
+  - terraform init -backend=false
+  - terraform validate
+  - terragrunt plan -no-color -target='module.webapps[0].azurerm_linux_web_app.api' -target='module.webapps[0].azurerm_linux_web_app_slot.api_staging'
+verification:
+  - Terraform init and validate succeeded.
+  - Targeted API/App Service plan shows 0 add, 2 in-place changes, adding API routing settings only.
+  - DOCKET_BASE_URL is intentionally omitted from the plan while Docket is blocked.
+blockers:
+  - CogMesh-to-Docket auth scheme is not confirmed.
+  - CogMesh-to-Docket production ingestion contract is not confirmed against the canonical Docket API.
+  - CogMesh-to-Sluice auth scheme still needs production confirmation.
+  - Full prod Terragrunt plan is not apply-safe yet because frontend App Service drift would remove existing frontend settings and move images back to Terraform-managed values.
+  - Current local CogMesh checkout remains dirty with migration documentation and Terraform changes only.
+risks:
+  - Applying the full prod plan without drift reconciliation could remove frontend app settings managed outside Terraform.
+  - The canonical Docket hostname currently fronts the existing pvc-shared-costops-api Container App; Docket repo naming and Terraform resource names still need follow-up cleanup.
+rollback_state:
+  - No repository transfer performed.
+  - No Terraform apply performed.
+  - Docket hostname rollback is to repoint docket.phoenixvc.tech CNAME away from the Container App and remove the Container App hostname binding.
+  - Cognitive Mesh changes remain local documentation and Terraform configuration only.
+next_action:
+  - Confirm CogMesh-to-Docket auth and production usage-ingestion contract, then set DOCKET_BASE_URL to https://docket.phoenixvc.tech only if compatible.
+  - Reconcile frontend App Service Terraform drift before any full prod apply.
+  - Apply the API-only Sluice routing settings only after Sluice auth is confirmed.
+  - Continue CogMesh org migration only after Sluice/Docket routing blockers are resolved.
+funding_impact:
+  - Positive once resolved: Docket plus Sluice will provide credible model usage/cost evidence for AI-credit applications.
+  - Current state remains partial because cost attribution is not yet canonical/live through Docket.
+```

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -179,9 +179,10 @@ work_completed:
       - SLUICE_MODEL
       - SLUICE_MAX_TOKENS
       - optional DOCKET_BASE_URL
+      - staging.cognitivemesh.neuralliquid.ai CORS origin
   - Set prod Sluice base URL to the verified LiteLLM gateway:
       - https://litellm.sluice.phoenixvc.tech
-  - Left DOCKET_BASE_URL empty because shared-costops has been renamed to Docket and the canonical Docket service is not yet live.
+  - Left DOCKET_BASE_URL empty because the canonical Docket endpoint is live but not approved for CogMesh until auth and usage-ingestion semantics are confirmed.
   - Updated manifest and this handoff with the Docket blocker.
   - Configured canonical Docket API hostname:
       - docket.phoenixvc.tech CNAME -> pvc-shared-costops-api.ashymushroom-1f7d8121.southafricanorth.azurecontainerapps.io
@@ -216,14 +217,14 @@ tests_run:
   - terragrunt plan -no-color -target='module.webapps[0].azurerm_linux_web_app.api' -target='module.webapps[0].azurerm_linux_web_app_slot.api_staging'
 verification:
   - Terraform init and validate succeeded.
-  - Targeted API/App Service plan shows 0 add, 2 in-place changes, adding API routing settings only.
-  - DOCKET_BASE_URL is intentionally omitted from the plan while Docket is blocked.
+  - Targeted API/App Service plan shows 0 add, 2 in-place changes, adding API routing settings and the missing staging CORS origin.
+  - DOCKET_BASE_URL is intentionally omitted from the plan while Docket auth and ingestion semantics are blocked.
 blockers:
   - CogMesh-to-Docket auth scheme is not confirmed.
   - CogMesh-to-Docket production ingestion contract is not confirmed against the canonical Docket API.
   - CogMesh-to-Sluice auth scheme still needs production confirmation.
   - Full prod Terragrunt plan is not apply-safe yet because frontend App Service drift would remove existing frontend settings and move images back to Terraform-managed values.
-  - Current local CogMesh checkout remains dirty with migration documentation and Terraform changes only.
+  - Batch 2 changes are split into clean PR branches: migration package PR #512 and Terraform routing PR #513.
 risks:
   - Applying the full prod plan without drift reconciliation could remove frontend app settings managed outside Terraform.
   - The canonical Docket hostname currently fronts the existing pvc-shared-costops-api Container App; Docket repo naming and Terraform resource names still need follow-up cleanup.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -147,7 +147,7 @@ Delivered:
 Current production behavior:
 
 - Sluice reports `configuration_missing` until `SLUICE_BASE_URL` is set.
-- Azure metadata confirms the Sluice LiteLLM gateway custom domain is `https://litellm.sluice.phoenixvc.tech`; CogMesh prod Terraform now has a non-secret hook for `SLUICE_BASE_URL`.
+- Azure metadata confirms the Sluice LiteLLM gateway custom domain is `https://litellm.sluice.phoenixvc.tech`; CogMesh prod Terraform now has non-secret hooks for `SLUICE_BASE_URL` and a Key Vault reference for `SLUICE_API_KEY`, but leaves them unset until auth is confirmed.
 - Docket reports `in-memory` until `DOCKET_BASE_URL` is set.
 - Docket canonical API URL is now live at `https://docket.phoenixvc.tech`.
 - Do not set `DOCKET_BASE_URL` until CogMesh-to-Docket auth and the production ingestion contract are confirmed. The current canonical host fronts the existing `pvc-shared-costops-api` Container App while Docket naming and IaC catch up.
@@ -176,11 +176,12 @@ work_completed:
   - Added Terraform hooks for Cognitive Mesh API routing settings:
       - ALLOW_DIRECT_MODEL_PROVIDER=false
       - SLUICE_BASE_URL
+      - Key Vault reference hook for SLUICE_API_KEY
       - SLUICE_MODEL
       - SLUICE_MAX_TOKENS
       - optional DOCKET_BASE_URL
       - staging.cognitivemesh.neuralliquid.ai CORS origin
-  - Set prod Sluice base URL to the verified LiteLLM gateway:
+  - Verified the intended prod Sluice base URL but left it gated on a managed API key reference:
       - https://litellm.sluice.phoenixvc.tech
   - Left DOCKET_BASE_URL empty because the canonical Docket endpoint is live but not approved for CogMesh until auth and usage-ingestion semantics are confirmed.
   - Updated manifest and this handoff with the Docket blocker.
@@ -217,7 +218,7 @@ tests_run:
   - terragrunt plan -no-color -target='module.webapps[0].azurerm_linux_web_app.api' -target='module.webapps[0].azurerm_linux_web_app_slot.api_staging'
 verification:
   - Terraform init and validate succeeded.
-  - Targeted API/App Service plan shows 0 add, 2 in-place changes, adding API routing settings and the missing staging CORS origin.
+  - Targeted API/App Service plan shows 0 add, 2 in-place changes, adding direct-provider blocking and the missing staging CORS origin when Sluice env hooks are unset.
   - DOCKET_BASE_URL is intentionally omitted from the plan while Docket auth and ingestion semantics are blocked.
 blockers:
   - CogMesh-to-Docket auth scheme is not confirmed.
@@ -236,7 +237,7 @@ rollback_state:
 next_action:
   - Confirm CogMesh-to-Docket auth and production usage-ingestion contract, then set DOCKET_BASE_URL to https://docket.phoenixvc.tech only if compatible.
   - Reconcile frontend App Service Terraform drift before any full prod apply.
-  - Apply the API-only Sluice routing settings only after Sluice auth is confirmed.
+  - Apply Sluice routing settings only after Sluice auth is confirmed and `COGMESH_SLUICE_BASE_URL` plus `COGMESH_SLUICE_API_KEY_SECRET_URI` are supplied.
   - Continue CogMesh org migration only after Sluice/Docket routing blockers are resolved.
 funding_impact:
   - Positive once resolved: Docket plus Sluice will provide credible model usage/cost evidence for AI-credit applications.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
@@ -28,7 +28,6 @@ decisions:
     - prod
   initial_domains:
     - staging.cognitivemesh.neuralliquid.ai
-    - prod.cognitivemesh.neuralliquid.ai
     - cognitivemesh.neuralliquid.ai
   eliminate_or_disable_expensive_nonessential_resources: true
   dns_source_of_truth_decision: "Use Mystira workspace Terraform only as a temporary bridge if it currently owns neuralliquid.ai DNS; move NeuralLiquid-owned DNS/deployment state to NeuralLiquid-owned infrastructure before long-term production."
@@ -303,6 +302,10 @@ references:
       source: README.md ecosystem table
       classification: PhoenixVC-hosted dependency
       action: retain PhoenixVC owner and clarify org-intelligence boundary until NeuralLiquid org-meta exists
+    - value: mcp-org
+      source: migration plan and cross-repository infrastructure inventory
+      classification: PhoenixVC-hosted dependency
+      action: retain PhoenixVC owner and clarify MCP aggregation boundary
     - value: mystira-workspace
       source: README.md ecosystem table
       classification: PhoenixVC-hosted dependency
@@ -323,7 +326,7 @@ references:
 blockers:
   - Batch 2 transfer remains partial until migration package PR #512 and companion Terraform routing PR #513 are reviewed and merged.
   - Deployment workflows still need the local workflow/Terraform changes to be committed and pushed before GitHub Actions will use the new Web App deployment path.
-  - Old cognitivemesh.io DNS names do not resolve; replace with staging.cognitivemesh.neuralliquid.ai, prod.cognitivemesh.neuralliquid.ai, and cognitivemesh.neuralliquid.ai.
+  - Old cognitivemesh.io DNS names do not resolve; replace with staging.cognitivemesh.neuralliquid.ai and cognitivemesh.neuralliquid.ai.
   - After repository transfer, add equivalent federated credential subjects for neuralliquid/cognitive-mesh to nl-cognitive-mesh-github-actions or a NeuralLiquid-owned replacement app registration.
   - GitHub Apps with selected repository access still need per-app repository selection confirmation before transfer; selected installations are visible, but expanding selected app repository lists through the API returned 403 and requires the broader GitHub OAuth `user` scope.
   - Docket must be live under canonical `docket` service identity before CogMesh sets `DOCKET_BASE_URL`; do not use the old `pvc-shared-costops-api` endpoint as the long-term dependency.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
@@ -4,9 +4,11 @@ generated_at: 2026-07-12
 generated_from:
   local_checkout: C:/tmp/cognitive-mesh
   default_branch: dev
-  head_sha: da03b47e3a62989495b0d7715273ed30dd78dc39
-  task_scope: "Pre-transfer discovery plus local CI/CD and Terraform prep; no repository transfer, archive, production app apply, or deployment workflow run."
-  followup_checked_at: 2026-07-12
+  origin_dev_sha_checked_at_2026_07_13: 5b76bf34389b0a82dcc546c2eb09d0494cb09e1e
+  local_branch: agent/adaptive-balance-control-widget
+  local_head_sha: 5ba6d9d0e96611baed977cf9c439cb58a5a4d708
+  task_scope: "Batch 2 reference inventory and rollback package plus Sluice/Docket routing prep; no repository transfer, archive, Terraform apply, production app apply, or deployment workflow run."
+  followup_checked_at: 2026-07-13
 
 decisions:
   preserve_internal_namespaces: true
@@ -319,10 +321,12 @@ references:
   archived_prototypes: []
 
 blockers:
+  - Batch 2 transfer remains partial until migration package PR #512 and companion Terraform routing PR #513 are reviewed and merged.
   - Deployment workflows still need the local workflow/Terraform changes to be committed and pushed before GitHub Actions will use the new Web App deployment path.
   - Old cognitivemesh.io DNS names do not resolve; replace with staging.cognitivemesh.neuralliquid.ai, prod.cognitivemesh.neuralliquid.ai, and cognitivemesh.neuralliquid.ai.
   - After repository transfer, add equivalent federated credential subjects for neuralliquid/cognitive-mesh to nl-cognitive-mesh-github-actions or a NeuralLiquid-owned replacement app registration.
-  - GitHub Apps with selected repository access still need per-app repository selection confirmation before transfer; expanding selected app repository lists through the API requires read:user scope.
+  - GitHub Apps with selected repository access still need per-app repository selection confirmation before transfer; selected installations are visible, but expanding selected app repository lists through the API returned 403 and requires the broader GitHub OAuth `user` scope.
+  - Docket must be live under canonical `docket` service identity before CogMesh sets `DOCKET_BASE_URL`; do not use the old `pvc-shared-costops-api` endpoint as the long-term dependency.
 
 resolved_blockers:
   - User confirmed the stale phoenix-flow ecosystem entry should be baton; manifest now classifies baton as the PhoenixVC-hosted project tracker dependency.
@@ -344,6 +348,7 @@ resolved_blockers:
   - Terraform validate succeeds with AzureRM provider 4.80.0 after updating the Cosmos DB connection string output for provider 4.x.
   - The only visible OpenAI resource match is pvc-prod-sluice-aoai in pvc-prod-sluice-rg, supporting the README claim that model access should route through sluice rather than a Cognitive Mesh-owned AOAI resource.
   - GitHub App installation inventory is visible for phoenixvc. Relevant installed apps include Renovate, Stilla, Codecov, Cursor, ChatGPT Codex Connector, Claude, Vercel, Sentry, CodeRabbit, Greptile, Devin, and phoenixvc-actions-runner.
+  - Selected app installation IDs were narrowed on 2026-07-13: Renovate `101140936`, Stilla `116485390`, Devin `68460896`, and phoenixvc-actions-runner `111911804`.
   - GitHub package inventory is visible; no phoenixvc Cognitive Mesh container packages were found.
   - Organization Actions secrets and variables are visible; org variables are empty and org secrets do not contain the ACR/AKS/Slack names required by Cognitive Mesh deployment workflows.
 
@@ -367,7 +372,7 @@ validation:
     - orgs/phoenixvc/actions/variables
     - orgs/phoenixvc/installations
     - orgs/phoenixvc/packages?package_type=container
-    - /user/installations/{installation_id}/repositories for selected apps (blocked by missing read:user)
+    - /user/installations/{installation_id}/repositories for selected apps (still blocked on 2026-07-13; GitHub returned 403 and requested OAuth user scope)
   azure_queries:
     - az account show
     - az resource list for Cognitive Mesh and mesh names

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
@@ -303,7 +303,6 @@ Updated deployment decision:
 - `staging` is a production slot, not an independent long-lived staging environment.
 - Target domain pattern for now:
   - `staging.cognitivemesh.neuralliquid.ai`
-  - `prod.cognitivemesh.neuralliquid.ai`
   - `cognitivemesh.neuralliquid.ai`
 - Eliminate or disable expensive nonessential resources for the initial deployment.
 - DNS is currently managed in Mystira workspace Terraform; this can be used as a temporary bridge, but NeuralLiquid-owned DNS/deployment state should move to NeuralLiquid-owned infrastructure before long-term production.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
@@ -16,8 +16,11 @@ This started as a metadata snapshot and now also records the local CI/CD and Ter
 - Archived: false
 - Disabled: false
 - Default branch: `dev`
-- HEAD SHA in local clone: `da03b47e3a62989495b0d7715273ed30dd78dc39`
-- Latest local commit: `da03b47e3a62989495b0d7715273ed30dd78dc39 2026-07-12T11:30:02+02:00 fix(deps): replace dependency framer-motion with motion 12.42.2 (#493)`
+- Latest fetched `origin/dev` SHA checked on 2026-07-13: `5b76bf34389b0a82dcc546c2eb09d0494cb09e1e`
+- Current local branch checked on 2026-07-13: `agent/adaptive-balance-control-widget`
+- HEAD SHA in local clone: `5ba6d9d0e96611baed977cf9c439cb58a5a4d708`
+- Latest local commit: `5ba6d9d0e96611baed977cf9c439cb58a5a4d708 feat: wire live governance widgets`
+- Snapshot caution: the original local discovery checkout was not a clean `dev` baseline. The migration package was later isolated into PR #512 from `origin/dev`; Terraform routing settings were isolated into companion PR #513.
 - Repository description: `Enterprise agent/LLM platform - RBAC, audit, Azure OpenAI, RAG. Relaunching as neuralliquid.ai`
 - Homepage: empty
 - Primary language: C#
@@ -199,7 +202,12 @@ These names must be validated as repository, organization, or environment secret
   - `devin-ai-integration` - selected repositories
   - `phoenixvc-actions-runner` - selected repositories
 - Selected-repository app installations still need repository selection confirmation before transfer, especially `renovate`, `stilla`, `devin-ai-integration`, and `phoenixvc-actions-runner`.
-- Attempting to expand selected app repository lists through `/user/installations/{installation_id}/repositories` returned 403 and requires `read:user` scope.
+- Selected app installation IDs were narrowed on 2026-07-13:
+  - `devin-ai-integration`: `68460896`
+  - `renovate`: `101140936`
+  - `phoenixvc-actions-runner`: `111911804`
+  - `stilla`: `116485390`
+- Attempting to expand selected app repository lists through `/user/installations/{installation_id}/repositories` still returned 403 on 2026-07-13 and requires the broader GitHub OAuth `user` scope, not only `read:user`.
 
 ## Pages
 
@@ -423,11 +431,11 @@ This rollback is incomplete until the blockers below are resolved.
 
 ## Blockers Before Transfer
 
-- Deploy workflows require unset variables: `AZURE_WEBAPP_RESOURCE_GROUP`, `COGNITIVE_MESH_API_APP_NAME`, and `COGNITIVE_MESH_FRONTEND_APP_NAME`.
-- Deployment workflows still need the local workflow/Terraform changes to be committed and pushed before GitHub Actions will use the new Web App deployment path.
+- Batch 2 artifacts and routing Terraform changes are isolated into clean PR branches and must be reviewed/merged before transfer: migration package PR #512 and Terraform routing PR #513.
+- Deployment workflows still need any approved local workflow/Terraform changes to be committed and pushed before GitHub Actions will use the new Web App deployment path.
 - Old `cognitivemesh.io`, `staging.cognitivemesh.io`, and `api.cognitivemesh.io` do not resolve; replace with `*.cognitivemesh.neuralliquid.ai`.
 - After repository transfer, add equivalent federated credential subjects for `neuralliquid/cognitive-mesh` to `nl-cognitive-mesh-github-actions` or a NeuralLiquid-owned replacement app registration.
-- Selected-repository GitHub App coverage still needs confirmation for `cognitive-mesh`, especially Renovate, Stilla, Devin, and phoenixvc-actions-runner; API expansion requires `read:user` scope or manual org UI review.
+- Selected-repository GitHub App coverage still needs confirmation for `cognitive-mesh`, especially Renovate, Stilla, Devin, and phoenixvc-actions-runner; API expansion returned 403 and requires OAuth `user` scope or manual org UI review.
 
 ## Resolved Or Narrowed Blockers
 
@@ -444,15 +452,21 @@ This rollback is incomplete until the blockers below are resolved.
 - Prod Terragrunt apply completed; final Terragrunt plan reports no changes.
 - GitHub Actions variables were populated on `phoenixvc/cognitive-mesh`.
 - GitHub Actions OIDC secrets were populated on `phoenixvc/cognitive-mesh`: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`.
+- Deploy workflow variable setup is resolved for the currently recorded PhoenixVC deployment path, but must be recreated or validated again after transfer to `neuralliquid/cognitive-mesh`.
 - Terraform validation succeeds with AzureRM `4.80.0`.
 - Sluice-owned AOAI resource `pvc-prod-sluice-aoai` was found, supporting the architecture boundary that Cognitive Mesh should route model calls through `sluice`.
 - GitHub App installation inventory is now visible at org level; 40 installations were found.
+- Selected app installation IDs are now known, but repository membership remains blocked by OAuth scope.
 - GitHub package inventory is now visible; no Cognitive Mesh packages were found under `phoenixvc`.
 - Organization Actions secrets are now visible; `AZURE_CREDENTIALS` exists at org scope, but deployment workflow ACR/AKS/Slack secret names do not.
 
 ## Validation Performed
 
 - Cloned `https://github.com/phoenixvc/cognitive-mesh.git` to `C:/tmp/cognitive-mesh`.
+- Fetched `origin` on 2026-07-13 and confirmed `origin/dev` at `5b76bf34389b0a82dcc546c2eb09d0494cb09e1e`.
+- Confirmed local branch `agent/adaptive-balance-control-widget` at `5ba6d9d0e96611baed977cf9c439cb58a5a4d708` with uncommitted migration/Terraform work.
+- Queried selected GitHub App installation metadata and captured installation IDs for Renovate, Stilla, Devin and phoenixvc-actions-runner.
+- Retried `/user/installations/{installation_id}/repositories`; GitHub returned 403 and requested OAuth `user` scope.
 - Read `AGENTS.md` and `CLAUDE.md`.
 - Queried GitHub repository metadata, branches, releases, rulesets, environments, secrets, variables, hooks, deploy keys, deployments, Pages, and recent workflow runs.
 - Checked direct `staging` and `production` GitHub environments; both returned 404.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
@@ -1,0 +1,93 @@
+# Reference Inventory - NeuralLiquid Cognitive Mesh Migration
+
+Generated: 2026-07-13
+
+Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
+
+This file is the standalone reference inventory required by the migration plan. Detailed source evidence remains in `manifest.yaml` and `pre-transfer-snapshot.md`.
+
+## Active References To Replace Or Validate
+
+- GitHub repository URL: `https://github.com/phoenixvc/cognitive-mesh`
+  - Classification: active reference.
+  - Action: replace active clone, badge, issue, workflow and automation links after transfer; validate GitHub redirect.
+- GitHub clone URL: `https://github.com/phoenixvc/cognitive-mesh.git`
+  - Classification: active reference.
+  - Action: replace clone instructions and local automation remotes after transfer.
+- GitHub Actions provenance: `${{ github.server_url }}/${{ github.repository }}`
+  - Classification: active automation reference.
+  - Action: verify image labels, attestations and deployment metadata after transfer.
+- Deployment workflows: `.github/workflows/deploy.yml` and `.github/workflows/deploy-frontend.yml`
+  - Classification: active deployment references.
+  - Action: validate from the target repository after OIDC and secrets are recreated.
+
+## Current Ownership Statements To Rewrite
+
+- `README.md` currently positions Cognitive Mesh as part of the PhoenixVC platform.
+- GitHub repository description says `Relaunching as neuralliquid.ai`.
+- Repository topics include both `phoenixvc` and `neuralliquid`.
+
+Action: rewrite current ownership language to NeuralLiquid while preserving the PhoenixVC incubation note.
+
+## PhoenixVC-Hosted Dependencies To Retain
+
+These are not part of the Cognitive Mesh repository transfer:
+
+- `phoenixvc/sluice` - model routing, provider credentials, fallbacks, rate limits, cost controls, observability and AI egress policy.
+- `phoenixvc/docket` - cost attribution and usage analytics. Former `shared-costops`/`pvc-costops-analytics` naming is still visible in local docs and Azure resources.
+- `phoenixvc/retort` - scaffolding and build-time tooling.
+- `phoenixvc/deck` - operator tooling.
+- `phoenixvc/baton` - cross-repository task graph.
+- `phoenixvc/org-meta` - PhoenixVC metadata until a NeuralLiquid-owned registry exists.
+- `phoenixvc/mcp-org` - cross-repository MCP aggregation.
+- `phoenixvc/mystira-workspace` - temporary DNS/deployment bridge where it still owns zones.
+
+Action: keep PhoenixVC ownership where these are true dependencies and clarify the cross-organisation boundary.
+
+## Generated Sources
+
+- `.github/pr-361-review-issues.json`
+  - Classification: generated output.
+  - Action: find source workflow/generator before editing.
+- `src/UILayer/web/src/lib/api/generated`
+  - Classification: generated output.
+  - Action: fix OpenAPI/source generator and regenerate rather than hand-editing.
+
+## Deployment And Runtime References
+
+- Shared ACR: `myssharedacr.azurecr.io`
+  - Classification: active shared infrastructure.
+  - Action: retain for initial NeuralLiquid deployments.
+- Cognitive Mesh App Services:
+  - `cognitive-mesh-api-prod`
+  - `cognitive-mesh-frontend-prod`
+  - `cognitive-mesh-api-prod-staging`
+  - `cognitive-mesh-frontend-prod-staging`
+  - Classification: active production resources.
+  - Action: retain through transfer; validate final deploys from target org.
+- Sluice gateway:
+  - `https://litellm.sluice.phoenixvc.tech`
+  - Classification: PhoenixVC-hosted dependency.
+  - Action: configure as `SLUICE_BASE_URL` for CogMesh model egress once auth is confirmed.
+- Docket API:
+  - Classification: blocker.
+  - Action: do not point CogMesh production at the old `pvc-shared-costops-api` URL as the canonical Docket dependency. Get `phoenixvc/docket` live under its canonical API URL/domain first, then set `DOCKET_BASE_URL`.
+- Direct provider configuration:
+  - `providersettings.json`, Kubernetes config, and local tooling still expose Azure OpenAI/OpenAI-oriented variable names.
+  - Classification: migration-sensitive direct-provider reference.
+  - Action: keep provider secrets quarantined and route production model egress through Sluice; allow direct-provider configuration only as a local shim or explicitly approved exception.
+
+## Historical Records To Preserve
+
+- Migration handoffs and audit records under `docs/migrations/`.
+- Historical ADRs and archived analysis that accurately describe past PhoenixVC incubation or old project names.
+
+Action: preserve history; add current-location notes only where needed.
+
+## Unknown Or Blocked References
+
+- Selected-repository GitHub App access for Renovate, Stilla, Devin and phoenixvc-actions-runner still needs manual/API confirmation. Installation IDs are known, but `/user/installations/{installation_id}/repositories` returned 403 and requires OAuth `user` scope.
+- Docket canonical production endpoint and CogMesh-to-Docket auth scheme are not confirmed.
+- CogMesh-to-Sluice production auth scheme is not confirmed.
+- Batch 2 edits are now split into clean PR branches: migration package PR #512 and Terraform routing PR #513.
+- Direct model-provider secrets should remain quarantined until all model egress is verified through Sluice.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
@@ -73,7 +73,7 @@ Action: keep PhoenixVC ownership where these are true dependencies and clarify t
   - Classification: blocker.
   - Action: do not point CogMesh production at the old `pvc-shared-costops-api` URL as the canonical Docket dependency. Get `phoenixvc/docket` live under its canonical API URL/domain first, then set `DOCKET_BASE_URL`.
 - Direct provider configuration:
-  - `providersettings.json`, Kubernetes config, and local tooling still expose Azure OpenAI/OpenAI-oriented variable names.
+  - `providersettings.json`, local docker-compose/k8s manifests, and local tooling still expose Azure OpenAI/OpenAI-oriented variable names.
   - Classification: migration-sensitive direct-provider reference.
   - Action: keep provider secrets quarantined and route production model egress through Sluice; allow direct-provider configuration only as a local shim or explicitly approved exception.
 

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
@@ -1,0 +1,58 @@
+# Rollback Plan - NeuralLiquid Cognitive Mesh Migration
+
+Generated: 2026-07-13
+
+Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
+
+No repository transfer has been performed in this batch.
+
+## Current Rollback State
+
+- Repository still exists at `phoenixvc/cognitive-mesh`.
+- Latest fetched `origin/dev` checked on 2026-07-13 is `5b76bf34389b0a82dcc546c2eb09d0494cb09e1e`.
+- Batch 2 work has been split into clean PR branches from `origin/dev`: migration package PR #512 and Terraform routing PR #513.
+- Production App Services remain in `nl-prod-cognitive-mesh-rg`.
+- Deployment identity `nl-cognitive-mesh-github-actions` currently has PhoenixVC repository federated subjects.
+- Shared ACR remains `myssharedacr.azurecr.io`.
+- CogMesh production infrastructure keeps `enable_openai = false`.
+- Sluice is an external PhoenixVC-hosted dependency.
+- Docket is blocked until the canonical renamed service is live.
+
+## If Pre-Transfer Changes Need Reversal
+
+1. Stop any in-flight deploy workflows for Cognitive Mesh.
+2. Revert only the affected migration-prep commits or PRs.
+3. If changes are still local-only, discard or move only the Batch 2 migration/Terraform edits after confirming they are not user-owned work.
+4. Re-run Terraform validation and a prod plan before applying any infrastructure rollback.
+5. Confirm API and frontend health on the existing App Services.
+6. Update `handoff.md`, `verification.md` and Baton with the rollback evidence.
+
+## If A Future Repository Transfer Must Be Reversed
+
+1. Stop workflows that publish packages, push images or deploy infrastructure.
+2. Confirm the repository ID and both old/new GitHub URLs.
+3. Transfer the same repository back to `phoenixvc`, preserving history and repository ID.
+4. Restore or recreate:
+   - branch rules and rulesets;
+   - environments and approvals;
+   - repository and environment variables;
+   - secret names, never values in docs;
+   - webhooks and deploy keys;
+   - GitHub App repository selections;
+   - package/container permissions.
+5. Restore Azure OIDC federated subjects for the active repository owner.
+6. Re-run a fresh clone from the restored owner.
+7. Run build/test verification.
+8. Run one controlled deployment from the restored repository owner.
+9. Validate old/new GitHub redirects and public URLs.
+
+## Stop Conditions
+
+Stop rollback or transfer work if any of these remain unknown:
+
+- a production deployment identity cannot be tied to a known repository subject;
+- a selected GitHub App cannot be restored or inspected;
+- a private downstream consumer depends on the old repository URL;
+- a package or container registry path has unknown consumers;
+- Docket is still referenced by old `shared-costops` service identity but claimed as canonical;
+- any secret value would need to be copied into a file, log or prompt.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -60,7 +60,7 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Verified `https://docket.phoenixvc.tech/config/status` returns `backend=table` and `auth_disabled=false`.
 - Ran `terraform init -backend=false` in `infra`: succeeded.
 - Ran `terraform validate` in `infra`: succeeded.
-- Ran targeted `terragrunt plan -no-color` for the API App Service and API staging slot: plan shows two in-place API resource updates to add `ALLOW_DIRECT_MODEL_PROVIDER=false`, `SLUICE_BASE_URL`, `SLUICE_MODEL`, `SLUICE_MAX_TOKENS` and the missing CORS origin. `DOCKET_BASE_URL` is intentionally not present while Docket auth and ingestion contract remain unconfirmed.
+- Ran targeted `terragrunt plan -no-color` for the API App Service and API staging slot. With Sluice environment hooks unset, the plan shows two in-place API resource updates to add `ALLOW_DIRECT_MODEL_PROVIDER=false` and the missing CORS origin only. `SLUICE_BASE_URL`, `SLUICE_API_KEY`, and `DOCKET_BASE_URL` are intentionally not present until auth and ingestion contracts are confirmed.
 
 ## Changes To Verify Before Applying
 

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -1,0 +1,89 @@
+# Verification Record - NeuralLiquid Cognitive Mesh Migration
+
+Generated: 2026-07-13
+
+Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
+
+## Current Status
+
+Status: Batch 2 partial / blocked.
+
+Reason: Batch 2 migration artifacts exist and were refreshed on 2026-07-13, but the repository transfer remains blocked by model-egress and dependency-readiness work. The migration package is isolated in PR #512 from `origin/dev`, and Terraform routing settings are isolated in companion PR #513. CogMesh should route model calls through Sluice and should not configure Docket production usage attribution until CogMesh-to-Docket auth and ingestion semantics are confirmed against the canonical Docket endpoint.
+
+## Evidence Reviewed
+
+- `CLAUDE.md`
+- `AGENTS.md`
+- `docs/plans/neuralliquid-cognitive-mesh-cleanup.md` in Baton
+- `docs/plans/neuralliquid-migration-preflight-status.md` in Baton
+- `docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml`
+- `docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md`
+- `docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md`
+
+## Production Checks Previously Recorded
+
+From `handoff.md`:
+
+- `https://api.cognitivemesh.neuralliquid.ai/api/v1/model-routing/summary` returned `200`.
+- `https://api.cognitivemesh.neuralliquid.ai/api/v1/sluice/health` returned `200`.
+- `https://api.cognitivemesh.neuralliquid.ai/api/v1/docket/usage/recent` returned `200`.
+- `https://cognitive-mesh.neuralliquid.ai/control` redirected to login as expected.
+- `https://cognitive-mesh-frontend-prod.azurewebsites.net/api/health` returned healthy after frontend deploy.
+
+These checks verify status surfaces, not full live Sluice model execution or canonical Docket ingestion.
+
+## Local Verification Performed This Session
+
+- Fetched `origin` and confirmed `origin/dev` at `5b76bf34389b0a82dcc546c2eb09d0494cb09e1e`.
+- Confirmed current local branch `agent/adaptive-balance-control-widget` at `5ba6d9d0e96611baed977cf9c439cb58a5a4d708` with uncommitted Batch 2/Sluice-routing prep.
+- Confirmed the standalone Batch 2 artifacts exist: `manifest.yaml`, `pre-transfer-snapshot.md`, `reference-inventory.md`, `rollback.md`, and `verification.md`.
+- Confirmed one open PR exists, Renovate PR #494 (`renovate/pin-dependencies`) targeting `dev`; it does not overlap with the migration artifact/Terraform scope.
+- Narrowed selected GitHub App blocker to installation IDs for Renovate (`101140936`), Stilla (`116485390`), Devin (`68460896`) and phoenixvc-actions-runner (`111911804`).
+- Retried selected app repository expansion through `/user/installations/{installation_id}/repositories`; GitHub returned 403 and requested OAuth `user` scope.
+- Reviewed direct model-provider routing code paths.
+- Confirmed `LLMClientFactory` prefers Sluice when `SLUICE_BASE_URL` is configured and blocks direct providers unless `ALLOW_DIRECT_MODEL_PROVIDER` is explicitly enabled.
+- Confirmed `SluiceLLMProvider` exists for protocol-level completions and embeddings.
+- Queried Azure Container Apps metadata:
+  - Sluice LiteLLM gateway: `pvc-prod-sluice-ca`, custom domain `litellm.sluice.phoenixvc.tech`.
+  - Sluice dashboard: `pvc-prod-sluice-dashboard`, custom domain `sluice.phoenixvc.tech`.
+  - Old CostOps API: `pvc-shared-costops-api`, no custom domain returned.
+- Confirmed DNS resolves for:
+  - `litellm.sluice.phoenixvc.tech`
+  - `sluice.phoenixvc.tech`
+- Confirmed local `docket` checkout still has generated `pvc-costops-analytics` naming and Azure resources still use `pvc-shared-costops-*`.
+- Configured Docket canonical API hostname:
+  - `docket.phoenixvc.tech` CNAME points to `pvc-shared-costops-api.ashymushroom-1f7d8121.southafricanorth.azurecontainerapps.io`.
+  - `asuid.docket.phoenixvc.tech` TXT contains the Container App custom-domain verification ID.
+  - Managed certificate `mc-pvc-shared-cos-docket-phoenixvc-0990` is `Succeeded`.
+  - Container App hostname list shows `docket.phoenixvc.tech` with `SniEnabled`.
+- Verified `https://docket.phoenixvc.tech/health` returns `{"status":"ok","backend":"table"}`.
+- Verified `https://docket.phoenixvc.tech/config/status` returns `backend=table` and `auth_disabled=false`.
+- Ran `terraform init -backend=false` in `infra`: succeeded.
+- Ran `terraform validate` in `infra`: succeeded.
+- Ran targeted `terragrunt plan -no-color` for the API App Service and API staging slot: plan shows two in-place API resource updates to add `ALLOW_DIRECT_MODEL_PROVIDER=false`, `SLUICE_BASE_URL`, `SLUICE_MODEL`, `SLUICE_MAX_TOKENS` and the missing CORS origin. `DOCKET_BASE_URL` is intentionally not present while Docket auth and ingestion contract remain unconfirmed.
+
+## Changes To Verify Before Applying
+
+- API build after merging onto the current `dev` branch.
+- Full Terragrunt plan after frontend App Service drift is reconciled.
+- Production API app settings after apply.
+- Sluice authenticated route from CogMesh after auth is configured.
+- Docket authenticated usage-ingestion route from CogMesh after auth is configured.
+
+## Blockers
+
+- Migration package and Terraform routing edits are split into clean PR branches, but they are not merged yet.
+- CogMesh-to-Docket auth scheme is not confirmed.
+- CogMesh-to-Docket production ingestion contract is not confirmed against `https://docket.phoenixvc.tech`.
+- CogMesh-to-Sluice auth scheme still needs production confirmation.
+- Selected-repository GitHub App coverage still needs confirmation before transfer; installation IDs are known, but repository selection expansion is blocked by OAuth scope or manual org UI review.
+- Repository transfer must not proceed until blockers are resolved and a clean build/test baseline is recorded.
+
+## Next Verification Action
+
+1. Review and merge migration package PR #512 and Terraform routing PR #513 if accepted.
+2. Confirm selected app repository coverage manually in GitHub org settings or refresh `gh` with OAuth `user` scope and rerun the installation repository queries.
+3. Confirm CogMesh-to-Docket auth and usage-ingestion contract against `https://docket.phoenixvc.tech`.
+4. Configure CogMesh `DOCKET_BASE_URL` only after that endpoint contract and auth scheme are confirmed.
+5. Run Terraform validation and prod plan.
+6. Re-run API/frontend build checks from a clean `dev` baseline.


### PR DESCRIPTION
## What changed

- Refreshes the NeuralLiquid Cognitive Mesh migration handoff and Batch 2 package.
- Adds standalone reference-inventory.md, rollback.md, and verification.md artifacts.
- Records current origin/dev, production evidence, Sluice/Docket status, and narrowed transfer blockers.
- Narrows selected GitHub App coverage from an unknown to concrete installation IDs plus the OAuth user scope/manual-review blocker.

## Why

Batch 2 should be PR-visible even while transfer remains blocked. This gives the migration coordinator a durable rollback/reference package without performing repository transfer, archive, Terraform apply, deployment, or secret handling.

## Verification

- git diff --check origin/dev...HEAD
- Live checks recorded while preparing the package: Sluice gateway returned 401 without an API key; Docket /config/status returned auth_disabled=false with Entra metadata.

## Blockers left

- Confirm selected app repository coverage manually or rerun installation repository queries with OAuth user scope.
- Confirm CogMesh-to-Sluice API key/secret delivery.
- Confirm CogMesh-to-Docket auth and usage-ingestion contract before setting DOCKET_BASE_URL.
- No repository transfer until a clean build/test baseline is recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated migration handoff, manifest, and pre-transfer records with current revision, deployment, validation, and blocker details.
  - Added a reference inventory covering repository, deployment, runtime, and dependency references.
  - Added rollback procedures, stop conditions, and migration verification checklists.
  - Documented required Sluice/Docket routing and configuration steps, authentication updates, endpoints, and production behavior.
  - Recorded migration evidence, risks, next actions, and remaining verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->