### PR TITLE
docs: record cognitive mesh transfer baseline

### DIFF
--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -150,8 +150,20 @@ Current production behavior:
 - Azure metadata confirms the Sluice LiteLLM gateway custom domain is `https://litellm.sluice.phoenixvc.tech`; CogMesh prod Terraform now has non-secret hooks for `SLUICE_BASE_URL` and a Key Vault reference for `SLUICE_API_KEY`, but leaves them unset until auth is confirmed.
 - Docket reports `in-memory` until `DOCKET_BASE_URL` is set.
 - Docket canonical API URL is now live at `https://docket.phoenixvc.tech`.
-- Do not set `DOCKET_BASE_URL` until CogMesh-to-Docket auth and the production ingestion contract are confirmed. The current canonical host fronts the existing `pvc-shared-costops-api` Container App while Docket naming and IaC catch up.
+- Do not set `DOCKET_BASE_URL` until CogMesh-to-Docket auth and the production ingestion contract are implemented. The canonical Docket API has auth enabled and exposes bearer-secured cost/action endpoints, but it does not currently expose a CogMesh-compatible model-usage ingestion endpoint.
 - The Sluice health endpoint does not perform a live model call; it reports configuration/routing readiness and `liveProbeAttempted=false`.
+
+## Transfer Baseline Refresh - 2026-07-13
+
+- PR #512 and PR #513 are merged into `dev`.
+- Clean baseline worktree verified at `92aa06bffcfc981eea5cf981e0245ed8180c9bf5`.
+- `dotnet build CognitiveMesh.sln` succeeded with 0 warnings and 0 errors.
+- `dotnet test CognitiveMesh.sln --no-build` succeeded with 581 tests passed.
+- `pnpm install` in `src/UILayer/web` succeeded from the lockfile; pnpm ignored dependency build scripts under its approval policy.
+- `pnpm run lint` exited 0 with 53 existing warnings.
+- `pnpm run test -- --runInBand` succeeded with 18 suites and 137 tests passed; existing React `act(...)` console warning observed.
+- `pnpm run build` succeeded; existing Style Dictionary and Next config/deprecation warnings remain.
+- `gh auth status` now includes `admin:org`, `read:packages`, `repo`, and `user`, but all four selected GitHub App repository-coverage API calls still return HTTP 403 because GitHub requires a PAT, GitHub App-authorized token, or basic auth for that endpoint.
 
 ## Org Migration Tasks After Sluice Routing
 
@@ -221,11 +233,11 @@ verification:
   - Targeted API/App Service plan shows 0 add, 2 in-place changes, adding direct-provider blocking and the missing staging CORS origin when Sluice env hooks are unset.
   - DOCKET_BASE_URL is intentionally omitted from the plan while Docket auth and ingestion semantics are blocked.
 blockers:
-  - CogMesh-to-Docket auth scheme is not confirmed.
-  - CogMesh-to-Docket production ingestion contract is not confirmed against the canonical Docket API.
+  - CogMesh-to-Docket service auth is identifiable but not wired; Docket supports Azure AD bearer tokens and optional X-API-Key, but CogMesh does not currently send either to Docket.
+  - CogMesh-to-Docket production ingestion contract is not compatible yet; canonical Docket does not expose a model-usage ingestion endpoint matching CogMesh's local DocketUsageEvent.
   - CogMesh-to-Sluice auth scheme still needs production confirmation.
+  - Selected GitHub App repository coverage still needs manual org UI review or a PAT/GitHub App-authorized token; OAuth user scope did not clear the API blocker.
   - Full prod Terragrunt plan is not apply-safe yet because frontend App Service drift would remove existing frontend settings and move images back to Terraform-managed values.
-  - Batch 2 changes are split into clean PR branches: migration package PR #512 and Terraform routing PR #513.
 risks:
   - Applying the full prod plan without drift reconciliation could remove frontend app settings managed outside Terraform.
   - The canonical Docket hostname currently fronts the existing pvc-shared-costops-api Container App; Docket repo naming and Terraform resource names still need follow-up cleanup.
@@ -235,7 +247,8 @@ rollback_state:
   - Docket hostname rollback is to repoint docket.phoenixvc.tech CNAME away from the Container App and remove the Container App hostname binding.
   - Cognitive Mesh changes remain local documentation and Terraform configuration only.
 next_action:
-  - Confirm CogMesh-to-Docket auth and production usage-ingestion contract, then set DOCKET_BASE_URL to https://docket.phoenixvc.tech only if compatible.
+  - Define and implement CogMesh-to-Docket authenticated production usage ingestion before setting DOCKET_BASE_URL to https://docket.phoenixvc.tech.
+  - Confirm selected GitHub App repository coverage manually in GitHub org settings or with a token type accepted by GitHub's installation repositories endpoint.
   - Reconcile frontend App Service Terraform drift before any full prod apply.
   - Apply Sluice routing settings only after Sluice auth is confirmed and `COGMESH_SLUICE_BASE_URL` plus `COGMESH_SLUICE_API_KEY_SECRET_URI` are supplied.
   - Continue CogMesh org migration only after Sluice/Docket routing blockers are resolved.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -8,7 +8,7 @@ Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
 
 Status: Batch 2 partial / blocked.
 
-Reason: Batch 2 migration artifacts exist and were refreshed on 2026-07-13, but the repository transfer remains blocked by model-egress and dependency-readiness work. The migration package is isolated in PR #512 from `origin/dev`, and Terraform routing settings are isolated in companion PR #513. CogMesh should route model calls through Sluice and should not configure Docket production usage attribution until CogMesh-to-Docket auth and ingestion semantics are confirmed against the canonical Docket endpoint.
+Reason: Batch 2 migration artifacts exist and were refreshed on 2026-07-13, but the repository transfer remains blocked by model-egress and dependency-readiness work. PR #512 and PR #513 are merged into `dev`; the clean transfer baseline now builds and tests at commit `92aa06bffcfc981eea5cf981e0245ed8180c9bf5`. CogMesh should route model calls through Sluice and should not configure Docket production usage attribution until CogMesh-to-Docket auth and ingestion semantics are implemented against the canonical Docket endpoint.
 
 ## Evidence Reviewed
 
@@ -62,28 +62,45 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Ran `terraform validate` in `infra`: succeeded.
 - Ran targeted `terragrunt plan -no-color` for the API App Service and API staging slot. With Sluice environment hooks unset, the plan shows two in-place API resource updates to add `ALLOW_DIRECT_MODEL_PROVIDER=false` and the missing CORS origin only. `SLUICE_BASE_URL`, `SLUICE_API_KEY`, and `DOCKET_BASE_URL` are intentionally not present until auth and ingestion contracts are confirmed.
 
+## Refresh - 2026-07-13
+
+- Confirmed `gh auth status` after refresh shows token scopes `admin:org`, `gist`, `read:packages`, `repo`, and `user`.
+- Retried selected GitHub App repository expansion for Devin (`68460896`), Renovate (`101140936`), phoenixvc-actions-runner (`111911804`), and Stilla (`116485390`) via `/user/installations/{installation_id}/repositories`.
+- GitHub still returned HTTP 403 for all four installation IDs: the endpoint requires a GitHub App-authorized token, a PAT, or basic auth. The OAuth `user` scope did not clear this blocker in the current CLI environment.
+- Re-verified canonical Docket repository as `phoenixvc/docket`.
+- Re-verified `https://docket.phoenixvc.tech/health` returns HTTP 200 with `{"status":"ok","backend":"table"}`.
+- Re-verified `https://docket.phoenixvc.tech/config/status` returns HTTP 200 with `backend=table`, `auth_disabled=false`, Azure AD client id `f6c75495-4566-4263-9045-d2f4818b892d`, and tenant id `7edf4423-ccb3-4275-bc80-64dae3ef0148`.
+- Re-verified `https://docket.phoenixvc.tech/openapi.json` returns HTTP 200.
+- Inspected Docket auth implementation. Docket protected endpoints use `Authorization: Bearer <token>` with Azure AD JWT validation when `AZURE_AD_TENANT_ID` and `AZURE_AD_CLIENT_ID` are set, with `X-API-Key` as a service-to-service fallback when `API_KEY` is configured.
+- Inspected Docket OpenAPI and source routes. The canonical Docket API exposes cost-centre, resource-group, budget, dashboard, action-log, and resource-action routes. It does not expose a CogMesh-compatible `POST /usage`, `POST /api/v1/docket/usage`, or equivalent model-usage ingestion route.
+- Inspected Cognitive Mesh Docket integration. `src/ApiHost/Program.cs` exposes local `GET /api/v1/docket/usage/recent` and `POST /api/v1/docket/usage`, backed by `InMemoryDocketUsageRecorder`; `DOCKET_BASE_URL` only changes status reporting to `external-ready` and does not currently wire outbound ingestion to Docket.
+- Updated clean baseline worktree to `origin/dev` at `92aa06bffcfc981eea5cf981e0245ed8180c9bf5`.
+- Ran `dotnet build CognitiveMesh.sln`: succeeded with 0 warnings and 0 errors.
+- Ran `dotnet test CognitiveMesh.sln --no-build`: succeeded, 581 tests passed.
+- Ran `pnpm install` in `src/UILayer/web`: succeeded from the lockfile; pnpm ignored build scripts for `esbuild`, `sharp`, and `unrs-resolver` under its approval policy.
+- Ran `pnpm run lint` in `src/UILayer/web`: exited 0 with 53 existing warnings.
+- Ran `pnpm run test -- --runInBand` in `src/UILayer/web`: succeeded, 18 suites and 137 tests passed; existing React `act(...)` console warning observed in `AuthContext.test.tsx`.
+- Ran `pnpm run build` in `src/UILayer/web`: succeeded; existing warnings remain for Style Dictionary token collisions, unsupported `eslint` key in `next.config.js`, and deprecated `middleware` convention.
+
 ## Changes To Verify Before Applying
 
-- API build after merging onto the current `dev` branch.
 - Full Terragrunt plan after frontend App Service drift is reconciled.
 - Production API app settings after apply.
 - Sluice authenticated route from CogMesh after auth is configured.
-- Docket authenticated usage-ingestion route from CogMesh after auth is configured.
+- Docket authenticated usage-ingestion route from CogMesh after Docket exposes or documents a compatible ingestion contract.
 
 ## Blockers
 
-- Migration package and Terraform routing edits are split into clean PR branches, but they are not merged yet.
-- CogMesh-to-Docket auth scheme is not confirmed.
-- CogMesh-to-Docket production ingestion contract is not confirmed against `https://docket.phoenixvc.tech`.
+- CogMesh-to-Docket service auth is identifiable but not wired: Docket supports Azure AD bearer tokens and optional `X-API-Key`, but CogMesh does not currently send either to Docket.
+- CogMesh-to-Docket production ingestion contract is blocked: Docket does not currently expose a matching model-usage ingestion endpoint for CogMesh's local `DocketUsageEvent` shape.
 - CogMesh-to-Sluice auth scheme still needs production confirmation.
-- Selected-repository GitHub App coverage still needs confirmation before transfer; installation IDs are known, but repository selection expansion is blocked by OAuth scope or manual org UI review.
-- Repository transfer must not proceed until blockers are resolved and a clean build/test baseline is recorded.
+- Selected-repository GitHub App coverage still needs confirmation before transfer; installation IDs are known, but repository selection expansion is blocked by token type. Manual org UI review or a PAT/GitHub App-authorized token is required.
+- Repository transfer must not proceed until blockers are resolved, even though the clean source build/test baseline is now recorded.
 
 ## Next Verification Action
 
-1. Review and merge migration package PR #512 and Terraform routing PR #513 if accepted.
-2. Confirm selected app repository coverage manually in GitHub org settings or refresh `gh` with OAuth `user` scope and rerun the installation repository queries.
-3. Confirm CogMesh-to-Docket auth and usage-ingestion contract against `https://docket.phoenixvc.tech`.
-4. Configure CogMesh `DOCKET_BASE_URL` only after that endpoint contract and auth scheme are confirmed.
-5. Run Terraform validation and prod plan.
-6. Re-run API/frontend build checks from a clean `dev` baseline.
+1. Confirm selected app repository coverage manually in GitHub org settings, or rerun the installation repository queries with a PAT/GitHub App-authorized token.
+2. Define and implement the Docket model-usage ingestion endpoint or adapter contract, including service auth.
+3. Configure CogMesh `DOCKET_BASE_URL` only after Docket has a compatible authenticated ingestion route.
+4. Confirm CogMesh-to-Sluice production auth.
+5. Run full Terraform validation and prod plan after frontend App Service drift is reconciled.


### PR DESCRIPTION
## Summary
- record the clean dev transfer baseline at 92aa06b after PR #512/#513 merged
- capture GitHub App coverage blocker after refreshed auth still returns installation repository 403s
- narrow Docket blocker to known auth modes plus missing CogMesh-compatible model-usage ingestion endpoint

## Verification
- dotnet build CognitiveMesh.sln
- dotnet test CognitiveMesh.sln --no-build
- pnpm install in src/UILayer/web
- pnpm run lint in src/UILayer/web (exits 0 with 53 existing warnings)
- pnpm run test -- --runInBand in src/UILayer/web
- pnpm run build in src/UILayer/web
- curl https://docket.phoenixvc.tech/health
- curl https://docket.phoenixvc.tech/config/status
- curl https://docket.phoenixvc.tech/openapi.json
- gh api /user/installations/{id}/repositories for Devin/Renovate/actions-runner/Stilla (all HTTP 403 token-type blocker)

No transfer, archive, Terraform apply, deployment, or secret handling performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration handoff and verification records with the latest transfer baseline status.
  * Documented successful build, test, and lint verification results.
  * Clarified current integration blockers involving authentication, usage reporting, health checks, and repository access.
  * Added follow-up steps for validating production integrations and safely applying infrastructure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->