### PR TITLE
docs: resolve github app coverage gate

### DIFF
--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -164,6 +164,11 @@ Current production behavior:
 - `pnpm run test -- --runInBand` succeeded with 18 suites and 137 tests passed; existing React `act(...)` console warning observed.
 - `pnpm run build` succeeded; existing Style Dictionary and Next config/deprecation warnings remain.
 - `gh auth status` now includes `admin:org`, `read:packages`, `repo`, and `user`, but all four selected GitHub App repository-coverage API calls still return HTTP 403 because GitHub requires a PAT, GitHub App-authorized token, or basic auth for that endpoint.
+- Classic PAT verification cleared the active GitHub App coverage gate:
+  - Renovate (`101140936`) includes `phoenixvc/cognitive-mesh`.
+  - Stilla (`116485390`) includes `phoenixvc/cognitive-mesh`.
+  - Devin (`68460896`) does not include `phoenixvc/cognitive-mesh`, accepted because Devin is inactive for this transfer.
+  - phoenixvc-actions-runner (`111911804`) has zero repositories, accepted because the runner app is not currently deployed.
 
 ## Org Migration Tasks After Sluice Routing
 
@@ -236,7 +241,6 @@ blockers:
   - CogMesh-to-Docket service auth is identifiable but not wired; Docket supports Azure AD bearer tokens and optional X-API-Key, but CogMesh does not currently send either to Docket.
   - CogMesh-to-Docket production ingestion contract is not compatible yet; canonical Docket does not expose a model-usage ingestion endpoint matching CogMesh's local DocketUsageEvent.
   - CogMesh-to-Sluice auth scheme still needs production confirmation.
-  - Selected GitHub App repository coverage still needs manual org UI review or a PAT/GitHub App-authorized token; OAuth user scope did not clear the API blocker.
   - Full prod Terragrunt plan is not apply-safe yet because frontend App Service drift would remove existing frontend settings and move images back to Terraform-managed values.
 risks:
   - Applying the full prod plan without drift reconciliation could remove frontend app settings managed outside Terraform.
@@ -248,7 +252,6 @@ rollback_state:
   - Cognitive Mesh changes remain local documentation and Terraform configuration only.
 next_action:
   - Define and implement CogMesh-to-Docket authenticated production usage ingestion before setting DOCKET_BASE_URL to https://docket.phoenixvc.tech.
-  - Confirm selected GitHub App repository coverage manually in GitHub org settings or with a token type accepted by GitHub's installation repositories endpoint.
   - Reconcile frontend App Service Terraform drift before any full prod apply.
   - Apply Sluice routing settings only after Sluice auth is confirmed and `COGMESH_SLUICE_BASE_URL` plus `COGMESH_SLUICE_API_KEY_SECRET_URI` are supplied.
   - Continue CogMesh org migration only after Sluice/Docket routing blockers are resolved.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -67,6 +67,12 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Confirmed `gh auth status` after refresh shows token scopes `admin:org`, `gist`, `read:packages`, `repo`, and `user`.
 - Retried selected GitHub App repository expansion for Devin (`68460896`), Renovate (`101140936`), phoenixvc-actions-runner (`111911804`), and Stilla (`116485390`) via `/user/installations/{installation_id}/repositories`.
 - GitHub still returned HTTP 403 for all four installation IDs: the endpoint requires a GitHub App-authorized token, a PAT, or basic auth. The OAuth `user` scope did not clear this blocker in the current CLI environment.
+- Retried the same installation repository queries with a classic PAT accepted by GitHub's installation repositories endpoint.
+- Confirmed Renovate (`101140936`) includes `phoenixvc/cognitive-mesh`.
+- Confirmed Stilla (`116485390`) includes `phoenixvc/cognitive-mesh`.
+- Confirmed Devin (`68460896`) does not include `phoenixvc/cognitive-mesh`; this is acceptable because Devin is inactive for this transfer.
+- Confirmed phoenixvc-actions-runner (`111911804`) has zero repositories; this is acceptable because the runner app is not currently deployed.
+- Selected GitHub App repository coverage is therefore no longer a transfer blocker for Batch 2: the active/required apps are covered, and the uncovered apps are explicitly not required.
 - Re-verified canonical Docket repository as `phoenixvc/docket`.
 - Re-verified `https://docket.phoenixvc.tech/health` returns HTTP 200 with `{"status":"ok","backend":"table"}`.
 - Re-verified `https://docket.phoenixvc.tech/config/status` returns HTTP 200 with `backend=table`, `auth_disabled=false`, Azure AD client id `f6c75495-4566-4263-9045-d2f4818b892d`, and tenant id `7edf4423-ccb3-4275-bc80-64dae3ef0148`.
@@ -94,13 +100,11 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - CogMesh-to-Docket service auth is identifiable but not wired: Docket supports Azure AD bearer tokens and optional `X-API-Key`, but CogMesh does not currently send either to Docket.
 - CogMesh-to-Docket production ingestion contract is blocked: Docket does not currently expose a matching model-usage ingestion endpoint for CogMesh's local `DocketUsageEvent` shape.
 - CogMesh-to-Sluice auth scheme still needs production confirmation.
-- Selected-repository GitHub App coverage still needs confirmation before transfer; installation IDs are known, but repository selection expansion is blocked by token type. Manual org UI review or a PAT/GitHub App-authorized token is required.
 - Repository transfer must not proceed until blockers are resolved, even though the clean source build/test baseline is now recorded.
 
 ## Next Verification Action
 
-1. Confirm selected app repository coverage manually in GitHub org settings, or rerun the installation repository queries with a PAT/GitHub App-authorized token.
-2. Define and implement the Docket model-usage ingestion endpoint or adapter contract, including service auth.
-3. Configure CogMesh `DOCKET_BASE_URL` only after Docket has a compatible authenticated ingestion route.
-4. Confirm CogMesh-to-Sluice production auth.
-5. Run full Terraform validation and prod plan after frontend App Service drift is reconciled.
+1. Define and implement the Docket model-usage ingestion endpoint or adapter contract, including service auth.
+2. Configure CogMesh `DOCKET_BASE_URL` only after Docket has a compatible authenticated ingestion route.
+3. Confirm CogMesh-to-Sluice production auth.
+4. Run full Terraform validation and prod plan after frontend App Service drift is reconciled.


### PR DESCRIPTION
## Summary
- record PAT-backed GitHub App repository coverage verification
- mark Renovate and Stilla as covering phoenixvc/cognitive-mesh
- mark Devin and phoenixvc-actions-runner as non-required for this transfer because Devin is inactive and the runner app is not currently deployed
- remove selected GitHub App coverage from the active blocker list

## Verification
- user-provided gh api /user/installations/68460896/repositories --paginate output showed Devin does not include cognitive-mesh and only covers phoenix-website/phoenix-marketdata
- user-provided gh api /user/installations/101140936/repositories --paginate output showed Renovate includes phoenixvc/cognitive-mesh
- user-provided gh api /user/installations/111911804/repositories --paginate output showed phoenixvc-actions-runner has zero repositories
- user-provided gh api /user/installations/116485390/repositories --paginate output showed Stilla includes phoenixvc/cognitive-mesh

No app access changes, repo transfer, archive, Terraform apply, deployment, or secret handling performed.