### PR TITLE
feat(api): forward Docket usage events

### DIFF
--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -78,8 +78,8 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Re-verified `https://docket.phoenixvc.tech/config/status` returns HTTP 200 with `backend=table`, `auth_disabled=false`, Azure AD client id `f6c75495-4566-4263-9045-d2f4818b892d`, and tenant id `7edf4423-ccb3-4275-bc80-64dae3ef0148`.
 - Re-verified `https://docket.phoenixvc.tech/openapi.json` returns HTTP 200.
 - Inspected Docket auth implementation. Docket protected endpoints use `Authorization: Bearer <token>` with Azure AD JWT validation when `AZURE_AD_TENANT_ID` and `AZURE_AD_CLIENT_ID` are set, with `X-API-Key` as a service-to-service fallback when `API_KEY` is configured.
-- Inspected Docket OpenAPI and source routes. The canonical Docket API exposes cost-centre, resource-group, budget, dashboard, action-log, and resource-action routes. It does not expose a CogMesh-compatible `POST /usage`, `POST /api/v1/docket/usage`, or equivalent model-usage ingestion route.
-- Inspected Cognitive Mesh Docket integration. `src/ApiHost/Program.cs` exposes local `GET /api/v1/docket/usage/recent` and `POST /api/v1/docket/usage`, backed by `InMemoryDocketUsageRecorder`; `DOCKET_BASE_URL` only changes status reporting to `external-ready` and does not currently wire outbound ingestion to Docket.
+- Implemented Docket PR `phoenixvc/docket#99`, adding protected model-usage ingestion routes at `POST /usage/model-events` and `POST /api/v1/usage/model-events`. JWT callers require the `Docket.UsageIngest` role; the existing `X-API-Key` service fallback remains available for initial smoke testing.
+- Implemented Cognitive Mesh Docket outbound usage client support. `src/ApiHost/Program.cs` now keeps recent usage locally and forwards recorded `DocketUsageEvent` payloads to Docket when `DOCKET_BASE_URL` is configured. Auth is selected in this order: `DOCKET_API_KEY`, `DOCKET_BEARER_TOKEN`, then Entra token acquisition from `DOCKET_SCOPE` or `DOCKET_AUDIENCE`.
 - Updated clean baseline worktree to `origin/dev` at `92aa06bffcfc981eea5cf981e0245ed8180c9bf5`.
 - Ran `dotnet build CognitiveMesh.sln`: succeeded with 0 warnings and 0 errors.
 - Ran `dotnet test CognitiveMesh.sln --no-build`: succeeded, 581 tests passed.
@@ -93,18 +93,18 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Full Terragrunt plan after frontend App Service drift is reconciled.
 - Production API app settings after apply.
 - Sluice authenticated route from CogMesh after auth is configured.
-- Docket authenticated usage-ingestion route from CogMesh after Docket exposes or documents a compatible ingestion contract.
+- Docket authenticated usage-ingestion route from CogMesh after Docket PR #99 and the CogMesh outbound client PR are merged and deployed with production settings.
 
 ## Blockers
 
-- CogMesh-to-Docket service auth is identifiable but not wired: Docket supports Azure AD bearer tokens and optional `X-API-Key`, but CogMesh does not currently send either to Docket.
-- CogMesh-to-Docket production ingestion contract is blocked: Docket does not currently expose a matching model-usage ingestion endpoint for CogMesh's local `DocketUsageEvent` shape.
+- CogMesh-to-Docket code-level contract is implemented but not production-smoked. Merge and deploy Docket PR #99, merge and deploy the CogMesh outbound client PR, then set `DOCKET_BASE_URL` plus either `DOCKET_AUDIENCE`/`DOCKET_SCOPE` for Entra app-role auth or `DOCKET_API_KEY` for the short bridge.
 - CogMesh-to-Sluice auth scheme still needs production confirmation.
 - Repository transfer must not proceed until blockers are resolved, even though the clean source build/test baseline is now recorded.
 
 ## Next Verification Action
 
-1. Define and implement the Docket model-usage ingestion endpoint or adapter contract, including service auth.
-2. Configure CogMesh `DOCKET_BASE_URL` only after Docket has a compatible authenticated ingestion route.
-3. Confirm CogMesh-to-Sluice production auth.
-4. Run full Terraform validation and prod plan after frontend App Service drift is reconciled.
+1. Merge and deploy Docket PR #99.
+2. Merge and deploy the CogMesh outbound Docket usage client PR.
+3. Configure CogMesh `DOCKET_BASE_URL` and service auth after Docket is deployed.
+4. Confirm CogMesh-to-Sluice production auth.
+5. Run full Terraform validation and prod plan after frontend App Service drift is reconciled.

--- a/src/ApiHost/ApiHost.csproj
+++ b/src/ApiHost/ApiHost.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
   </ItemGroup>
 

--- a/src/ApiHost/Program.cs
+++ b/src/ApiHost/Program.cs
@@ -1,9 +1,14 @@
 using AgencyLayer.CognitiveSandwich.Infrastructure;
+using Azure.Core;
+using Azure.Identity;
 using CognitiveMesh.AgencyLayer.RealTime.Infrastructure;
 using CognitiveMesh.BusinessApplications.AdaptiveBalance.Infrastructure;
 using CognitiveMesh.BusinessApplications.ImpactMetrics.Infrastructure;
 using CognitiveMesh.BusinessApplications.NISTCompliance.Infrastructure;
 using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,7 +34,7 @@ builder.Services.AddCognitiveSandwichServices();
 builder.Services.AddImpactMetricsServices();
 builder.Services.AddCognitiveMeshRealTime();
 builder.Services.AddSingleton<ModelRoutingTelemetryStore>();
-builder.Services.AddSingleton<IDocketUsageRecorder, InMemoryDocketUsageRecorder>();
+builder.Services.AddHttpClient<IDocketUsageRecorder, DocketUsageRecorder>();
 
 // CORS — allow the Next.js frontend during development
 builder.Services.AddCors(options =>
@@ -261,17 +266,30 @@ internal interface IDocketUsageRecorder
     IReadOnlyList<DocketUsageEvent> GetRecent(int maxResults);
 }
 
-internal sealed class InMemoryDocketUsageRecorder : IDocketUsageRecorder
+internal sealed class DocketUsageRecorder : IDocketUsageRecorder
 {
     private readonly ConcurrentQueue<DocketUsageEvent> _events = new();
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<DocketUsageRecorder> _logger;
+    private readonly TokenCredential _credential;
 
-    public InMemoryDocketUsageRecorder(IConfiguration configuration)
+    public DocketUsageRecorder(
+        HttpClient httpClient,
+        IConfiguration configuration,
+        ILogger<DocketUsageRecorder> logger)
     {
+        _httpClient = httpClient;
+        _configuration = configuration;
+        _logger = logger;
+        _credential = CreateCredential(configuration);
+
         var model = configuration["Sluice:Model"]
             ?? configuration["SLUICE_MODEL"]
             ?? "default";
 
-        Record(new DocketUsageEvent(
+        Enqueue(Normalize(new DocketUsageEvent(
             Guid.NewGuid().ToString(),
             "demo-tenant",
             null,
@@ -285,33 +303,23 @@ internal sealed class InMemoryDocketUsageRecorder : IDocketUsageRecorder
             0,
             "allowed",
             "recorded",
-            DateTimeOffset.UtcNow));
+            DateTimeOffset.UtcNow)));
     }
 
     public DocketUsageEvent Record(DocketUsageEvent usageEvent)
     {
-        var normalized = usageEvent with
-        {
-            CorrelationId = string.IsNullOrWhiteSpace(usageEvent.CorrelationId)
-                ? Guid.NewGuid().ToString()
-                : usageEvent.CorrelationId,
-            Source = string.IsNullOrWhiteSpace(usageEvent.Source) ? "CognitiveMesh" : usageEvent.Source,
-            Provider = string.IsNullOrWhiteSpace(usageEvent.Provider) ? "sluice" : usageEvent.Provider,
-            Model = string.IsNullOrWhiteSpace(usageEvent.Model) ? "default" : usageEvent.Model,
-            Status = string.IsNullOrWhiteSpace(usageEvent.Status) ? "recorded" : usageEvent.Status,
-            PolicyOutcome = string.IsNullOrWhiteSpace(usageEvent.PolicyOutcome) ? "unknown" : usageEvent.PolicyOutcome,
-            OccurredAt = usageEvent.OccurredAt == default ? DateTimeOffset.UtcNow : usageEvent.OccurredAt,
-            TotalTokens = usageEvent.TotalTokens > 0
-                ? usageEvent.TotalTokens
-                : Math.Max(0, usageEvent.PromptTokens + usageEvent.CompletionTokens)
-        };
+        var normalized = Normalize(usageEvent);
+        Enqueue(normalized);
+        _ = ForwardUsageAsync(normalized, CancellationToken.None);
+        return normalized;
+    }
 
+    private void Enqueue(DocketUsageEvent normalized)
+    {
         _events.Enqueue(normalized);
         while (_events.Count > 250 && _events.TryDequeue(out _))
         {
         }
-
-        return normalized;
     }
 
     public IReadOnlyList<DocketUsageEvent> GetRecent(int maxResults)
@@ -320,6 +328,149 @@ internal sealed class InMemoryDocketUsageRecorder : IDocketUsageRecorder
             .Reverse()
             .Take(Math.Clamp(maxResults, 1, 100))
             .ToArray();
+    }
+
+    private static DocketUsageEvent Normalize(DocketUsageEvent usageEvent)
+    {
+        var promptTokens = Math.Max(0, usageEvent.PromptTokens);
+        var completionTokens = Math.Max(0, usageEvent.CompletionTokens);
+
+        return usageEvent with
+        {
+            CorrelationId = string.IsNullOrWhiteSpace(usageEvent.CorrelationId)
+                ? Guid.NewGuid().ToString()
+                : usageEvent.CorrelationId,
+            Source = string.IsNullOrWhiteSpace(usageEvent.Source)
+                ? "CognitiveMesh"
+                : usageEvent.Source,
+            Provider = string.IsNullOrWhiteSpace(usageEvent.Provider)
+                ? "sluice"
+                : usageEvent.Provider,
+            Model = string.IsNullOrWhiteSpace(usageEvent.Model) ? "default" : usageEvent.Model,
+            Status = string.IsNullOrWhiteSpace(usageEvent.Status) ? "recorded" : usageEvent.Status,
+            PolicyOutcome = string.IsNullOrWhiteSpace(usageEvent.PolicyOutcome)
+                ? "unknown"
+                : usageEvent.PolicyOutcome,
+            OccurredAt = usageEvent.OccurredAt == default
+                ? DateTimeOffset.UtcNow
+                : usageEvent.OccurredAt,
+            PromptTokens = promptTokens,
+            CompletionTokens = completionTokens,
+            TotalTokens = usageEvent.TotalTokens > 0
+                ? usageEvent.TotalTokens
+                : promptTokens + completionTokens,
+            EstimatedCostUsd = Math.Max(0, usageEvent.EstimatedCostUsd)
+        };
+    }
+
+    private async Task ForwardUsageAsync(
+        DocketUsageEvent usageEvent,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = _configuration["Docket:BaseUrl"]
+            ?? _configuration["DOCKET_BASE_URL"]
+            ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return;
+        }
+
+        try
+        {
+            using var request = new HttpRequestMessage(
+                HttpMethod.Post,
+                new Uri(new Uri(baseUrl.TrimEnd('/') + "/"), "usage/model-events"));
+
+            await AddAuthenticationAsync(request, cancellationToken).ConfigureAwait(false);
+            request.Content = JsonContent.Create(ToDocketPayload(usageEvent), options: JsonOptions);
+
+            using var response = await _httpClient
+                .SendAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Docket usage ingestion returned {StatusCode} for correlation {CorrelationId}",
+                    (int)response.StatusCode,
+                    usageEvent.CorrelationId);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Docket usage ingestion failed for correlation {CorrelationId}",
+                usageEvent.CorrelationId);
+        }
+    }
+
+    private async Task AddAuthenticationAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var apiKey = _configuration["Docket:ApiKey"] ?? _configuration["DOCKET_API_KEY"];
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            request.Headers.Add("X-API-Key", apiKey);
+            return;
+        }
+
+        var staticBearer = _configuration["Docket:BearerToken"]
+            ?? _configuration["DOCKET_BEARER_TOKEN"];
+        if (!string.IsNullOrWhiteSpace(staticBearer))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", staticBearer);
+            return;
+        }
+
+        var scope = _configuration["Docket:Scope"] ?? _configuration["DOCKET_SCOPE"];
+        var audience = _configuration["Docket:Audience"] ?? _configuration["DOCKET_AUDIENCE"];
+        if (string.IsNullOrWhiteSpace(scope) && !string.IsNullOrWhiteSpace(audience))
+        {
+            scope = audience.TrimEnd('/') + "/.default";
+        }
+
+        if (string.IsNullOrWhiteSpace(scope))
+        {
+            return;
+        }
+
+        var token = await _credential
+            .GetTokenAsync(new TokenRequestContext([scope]), cancellationToken)
+            .ConfigureAwait(false);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+    }
+
+    private static object ToDocketPayload(DocketUsageEvent usageEvent)
+    {
+        return new
+        {
+            correlationId = usageEvent.CorrelationId,
+            source = usageEvent.Source,
+            provider = usageEvent.Provider,
+            model = usageEvent.Model,
+            promptTokens = usageEvent.PromptTokens,
+            completionTokens = usageEvent.CompletionTokens,
+            totalTokens = usageEvent.TotalTokens,
+            estimatedCostUsd = usageEvent.EstimatedCostUsd,
+            status = usageEvent.Status,
+            policyOutcome = usageEvent.PolicyOutcome,
+            occurredAt = usageEvent.OccurredAt
+        };
+    }
+
+    private static TokenCredential CreateCredential(IConfiguration configuration)
+    {
+        var managedIdentityClientId = configuration["Docket:ManagedIdentityClientId"]
+            ?? configuration["DOCKET_MANAGED_IDENTITY_CLIENT_ID"]
+            ?? configuration["AZURE_CLIENT_ID"];
+
+        return string.IsNullOrWhiteSpace(managedIdentityClientId)
+            ? new DefaultAzureCredential()
+            : new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            {
+                ManagedIdentityClientId = managedIdentityClientId
+            });
     }
 }
 
@@ -355,6 +506,15 @@ internal sealed record ModelRoutingStatus(
         var docketBaseUrl = configuration["Docket:BaseUrl"]
             ?? configuration["DOCKET_BASE_URL"]
             ?? string.Empty;
+        var docketAuthConfigured =
+            !string.IsNullOrWhiteSpace(configuration["Docket:ApiKey"] ?? configuration["DOCKET_API_KEY"])
+            || !string.IsNullOrWhiteSpace(configuration["Docket:BearerToken"] ?? configuration["DOCKET_BEARER_TOKEN"])
+            || !string.IsNullOrWhiteSpace(configuration["Docket:Scope"] ?? configuration["DOCKET_SCOPE"])
+            || !string.IsNullOrWhiteSpace(configuration["Docket:Audience"] ?? configuration["DOCKET_AUDIENCE"]);
+        var docketConfigured = !string.IsNullOrWhiteSpace(docketBaseUrl);
+        var docketMode = docketConfigured
+            ? docketAuthConfigured ? "external-auth-configured" : "external-auth-missing"
+            : "in-memory";
 
         var configured = !string.IsNullOrWhiteSpace(baseUrl);
         return new ModelRoutingStatus(
@@ -364,8 +524,8 @@ internal sealed record ModelRoutingStatus(
             configured ? baseUrl : "not configured",
             configured,
             directFallback,
-            !string.IsNullOrWhiteSpace(docketBaseUrl),
-            string.IsNullOrWhiteSpace(docketBaseUrl) ? "in-memory" : "external-ready",
+            docketConfigured,
+            docketMode,
             DateTimeOffset.UtcNow,
             Guid.NewGuid().ToString(),
             routingEvents.Count,


### PR DESCRIPTION
Summary: replaces the in-memory-only Docket recorder with an HTTP-aware recorder that keeps local recent events and forwards to Docket when DOCKET_BASE_URL is configured. Supports DOCKET_API_KEY bridge, DOCKET_BEARER_TOKEN, or Entra token acquisition from DOCKET_SCOPE/DOCKET_AUDIENCE. Updates migration verification notes to make remaining deploy/config smoke steps explicit. Depends on phoenixvc/docket#99. Verification: dotnet build src\ApiHost\ApiHost.csproj --no-restore; dotnet build CognitiveMesh.sln; dotnet test CognitiveMesh.sln --no-build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added outbound model-usage reporting to Docket when configured.
  * Supports API key, bearer token, or Entra-based authentication.
  * Added usage validation to prevent invalid token counts and costs.
  * Routing status now indicates whether external Docket authentication is configured.

* **Documentation**
  * Updated migration verification guidance with the new ingestion endpoints, configuration requirements, and deployment validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->