### PR TITLE
fix(deploy): support Docket API key bridge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -179,6 +179,13 @@ jobs:
             --name "${{ vars.COGNITIVE_MESH_API_APP_NAME }}" \
             --slot staging \
             --settings "${app_settings[@]}"
+          if [ -z "${COGMESH_DOCKET_API_KEY_SECRET_URI}" ] && [ -z "${COGMESH_DOCKET_API_KEY}" ]; then
+            az webapp config appsettings delete \
+              --resource-group "${{ vars.AZURE_WEBAPP_RESOURCE_GROUP }}" \
+              --name "${{ vars.COGNITIVE_MESH_API_APP_NAME }}" \
+              --slot staging \
+              --setting-names DOCKET_API_KEY || true
+          fi
 
       - name: Restart staging slot
         run: |
@@ -272,6 +279,12 @@ jobs:
             --resource-group "${{ vars.AZURE_WEBAPP_RESOURCE_GROUP }}" \
             --name "${{ vars.COGNITIVE_MESH_API_APP_NAME }}" \
             --settings "${app_settings[@]}"
+          if [ -z "${COGMESH_DOCKET_API_KEY_SECRET_URI}" ] && [ -z "${COGMESH_DOCKET_API_KEY}" ]; then
+            az webapp config appsettings delete \
+              --resource-group "${{ vars.AZURE_WEBAPP_RESOURCE_GROUP }}" \
+              --name "${{ vars.COGNITIVE_MESH_API_APP_NAME }}" \
+              --setting-names DOCKET_API_KEY || true
+          fi
 
       - name: Restart production
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,6 +127,8 @@ jobs:
           COGMESH_DOCKET_BASE_URL: ${{ vars.COGMESH_DOCKET_BASE_URL }}
           COGMESH_DOCKET_AUDIENCE: ${{ vars.COGMESH_DOCKET_AUDIENCE }}
           COGMESH_DOCKET_SCOPE: ${{ vars.COGMESH_DOCKET_SCOPE }}
+          COGMESH_DOCKET_API_KEY: ${{ secrets.COGMESH_DOCKET_API_KEY }}
+          COGMESH_DOCKET_API_KEY_SECRET_URI: ${{ vars.COGMESH_DOCKET_API_KEY_SECRET_URI }}
           COGMESH_SLUICE_BASE_URL: ${{ vars.COGMESH_SLUICE_BASE_URL }}
           COGMESH_SLUICE_MODEL: ${{ vars.COGMESH_SLUICE_MODEL || 'default' }}
           COGMESH_SLUICE_MAX_TOKENS: ${{ vars.COGMESH_SLUICE_MAX_TOKENS || '16384' }}
@@ -158,6 +160,11 @@ jobs:
           fi
           if [ -n "${COGMESH_DOCKET_SCOPE}" ]; then
             app_settings+=(DOCKET_SCOPE="${COGMESH_DOCKET_SCOPE}")
+          fi
+          if [ -n "${COGMESH_DOCKET_API_KEY_SECRET_URI}" ]; then
+            app_settings+=(DOCKET_API_KEY="@Microsoft.KeyVault(SecretUri=${COGMESH_DOCKET_API_KEY_SECRET_URI})")
+          elif [ -n "${COGMESH_DOCKET_API_KEY}" ]; then
+            app_settings+=(DOCKET_API_KEY="${COGMESH_DOCKET_API_KEY}")
           fi
           if [ -n "${COGMESH_SLUICE_BASE_URL}" ]; then
             app_settings+=(SLUICE_BASE_URL="${COGMESH_SLUICE_BASE_URL}")
@@ -215,6 +222,8 @@ jobs:
           COGMESH_DOCKET_BASE_URL: ${{ vars.COGMESH_DOCKET_BASE_URL }}
           COGMESH_DOCKET_AUDIENCE: ${{ vars.COGMESH_DOCKET_AUDIENCE }}
           COGMESH_DOCKET_SCOPE: ${{ vars.COGMESH_DOCKET_SCOPE }}
+          COGMESH_DOCKET_API_KEY: ${{ secrets.COGMESH_DOCKET_API_KEY }}
+          COGMESH_DOCKET_API_KEY_SECRET_URI: ${{ vars.COGMESH_DOCKET_API_KEY_SECRET_URI }}
           COGMESH_SLUICE_BASE_URL: ${{ vars.COGMESH_SLUICE_BASE_URL }}
           COGMESH_SLUICE_MODEL: ${{ vars.COGMESH_SLUICE_MODEL || 'default' }}
           COGMESH_SLUICE_MAX_TOKENS: ${{ vars.COGMESH_SLUICE_MAX_TOKENS || '16384' }}
@@ -245,6 +254,11 @@ jobs:
           fi
           if [ -n "${COGMESH_DOCKET_SCOPE}" ]; then
             app_settings+=(DOCKET_SCOPE="${COGMESH_DOCKET_SCOPE}")
+          fi
+          if [ -n "${COGMESH_DOCKET_API_KEY_SECRET_URI}" ]; then
+            app_settings+=(DOCKET_API_KEY="@Microsoft.KeyVault(SecretUri=${COGMESH_DOCKET_API_KEY_SECRET_URI})")
+          elif [ -n "${COGMESH_DOCKET_API_KEY}" ]; then
+            app_settings+=(DOCKET_API_KEY="${COGMESH_DOCKET_API_KEY}")
           fi
           if [ -n "${COGMESH_SLUICE_BASE_URL}" ]; then
             app_settings+=(SLUICE_BASE_URL="${COGMESH_SLUICE_BASE_URL}")


### PR DESCRIPTION
## Summary
- let the API deploy workflow set DOCKET_API_KEY from a GitHub secret when the temporary bridge is needed
- prefer COGMESH_DOCKET_API_KEY_SECRET_URI when a Key Vault exists
- keep the setting absent when neither secret nor Key Vault URI is configured

## Why
Docket and Cognitive Mesh are currently in different Entra tenants. This supports the explicit X-API-Key bridge while the preferred cross-tenant Entra app-role auth is completed.

## Verification
- actionlint .github/workflows/deploy.yml
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced Docket API connectivity for both staging and production container deployments.
  - Docket API credentials now support secure loading from Azure Key Vault (secret URI form) or fallback to a directly configured API key.
  - If staging or production inputs are left empty, the existing Docket API key setting is cleared to avoid stale configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->