### PR TITLE
docs(agent-ops): add workflow contract schemas

### DIFF
--- a/docs/orchestration-evaluation/README.md
+++ b/docs/orchestration-evaluation/README.md
@@ -29,10 +29,12 @@ Weighted evaluation of agent orchestration approaches across **4 internal reposi
 ## Agent Contract Gates
 
 The benchmark harness now has a machine-readable contract surface in
-[`../spec/agent-contracts/`](../spec/agent-contracts/). Use those schemas when a
-workflow needs to move from `specified` to `harnessed`, `verified`, or
-`promoted`; use this evaluation package as the evidence source for latency,
-fan-out throughput, failure recovery, and MAKER long-horizon gates.
+[`../spec/agent-contracts/`](../spec/agent-contracts/). The implemented scope is
+schemas, shared gate identifiers, and reference examples. Lifecycle promotion
+from `specified` through `promoted` is not automated yet; it still requires the
+benchmark gates to run and evidence to be attached manually. Use this evaluation
+package as the evidence source for latency, fan-out throughput, failure
+recovery, and MAKER long-horizon gates.
 
 ## How to Read This Documentation
 

--- a/docs/orchestration-evaluation/README.md
+++ b/docs/orchestration-evaluation/README.md
@@ -26,6 +26,14 @@ Weighted evaluation of agent orchestration approaches across **4 internal reposi
 | [10 — Agent Prompt Patterns](10-agent-prompt-patterns/) | Actual prompts, system instructions, and behavioral rules used by major platforms |
 | [Appendices](appendices/) | Evidence index, glossary, decision tree, migration risk matrix |
 
+## Agent Contract Gates
+
+The benchmark harness now has a machine-readable contract surface in
+[`../spec/agent-contracts/`](../spec/agent-contracts/). Use those schemas when a
+workflow needs to move from `specified` to `harnessed`, `verified`, or
+`promoted`; use this evaluation package as the evidence source for latency,
+fan-out throughput, failure recovery, and MAKER long-horizon gates.
+
 ## How to Read This Documentation
 
 **Scoring**: All metrics use a 1.0–5.0 decimal scale. Percentage equivalents are `(score / 5) × 100`. Weighted totals apply profile-specific weights to each metric, then convert to percentage.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -19,6 +19,8 @@ This directory contains the OpenAPI specification for the Cognitive Mesh Convene
   - `notifications.yaml` - Event notifications system
 
 - `index.yaml` - Root document that combines all components and paths
+- `agent-contracts/` - JSON Schemas and examples for governed workflow contracts
+  and benchmark harness gates used by Agent Operating Model v0
 
 ## Development
 

--- a/docs/spec/agent-contracts/README.md
+++ b/docs/spec/agent-contracts/README.md
@@ -1,0 +1,37 @@
+# Agent Contract Schemas
+
+This directory defines the Cognitive Mesh side of Agent Operating Model v0. These
+schemas are the machine-readable boundary between generated repo guidance,
+runtime workflow execution, Baton evidence, model routing, cost routing, and
+benchmark promotion gates.
+
+## Files
+
+- `workflow-contract.schema.json` defines a governed multi-agent workflow:
+  trigger/input, ordered steps, state handoff, authority, tools, model route,
+  cost route, timeout/retry/backpressure/idempotency, approval, audit, rollback,
+  and evaluation gates.
+- `harness-contract.schema.json` defines the benchmark harness that decides
+  whether a workflow contract is harnessed, verified, or promotable.
+- `examples/standard-orchestration-workflow.contract.json` is the reference
+  workflow contract for the existing `DurableWorkflowEngine` surface.
+- `examples/standard-orchestration-harness.contract.json` binds the workflow to
+  the existing latency, fan-out throughput, failure recovery, and MAKER gates.
+
+## Gate Mapping
+
+The harness contract makes the existing
+`docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md`
+actionable:
+
+| Gate | Source | Critical threshold |
+|------|--------|--------------------|
+| Interactive coordination latency | Benchmark 1 | p95 < 200 ms |
+| Parallel fan-out throughput | Benchmark 2 | N=100 wall clock < 30 s and backpressure observed |
+| Failure injection and recovery | Benchmark 3 | correct final state and complete audit trail |
+| MAKER long-horizon execution | `MakerBenchmark` | at least 10 discs completed |
+
+Promotion from `specified` to `verified` requires all critical gates to pass and
+evidence artifacts to be attached to the task or release record. The schemas do
+not claim a workflow is currently verified; they define the contract required to
+produce that evidence.

--- a/docs/spec/agent-contracts/README.md
+++ b/docs/spec/agent-contracts/README.md
@@ -5,6 +5,22 @@ schemas are the machine-readable boundary between generated repo guidance,
 runtime workflow execution, Baton evidence, model routing, cost routing, and
 benchmark promotion gates.
 
+## Status
+
+Implemented in this repository:
+
+- JSON Schemas for workflow contracts, harness contracts, and shared benchmark
+  gate identifiers.
+- Reference examples for the existing `DurableWorkflowEngine` orchestration
+  surface.
+- Documentation links from the API spec and orchestration evaluation surfaces.
+
+Planned follow-up work:
+
+- Actual harness runners for latency, fan-out throughput, and failure recovery.
+- Automated evidence attachment to Baton or release records.
+- Automated lifecycle promotion from `specified` through `promoted`.
+
 ## Files
 
 - `workflow-contract.schema.json` defines a governed multi-agent workflow:
@@ -13,6 +29,8 @@ benchmark promotion gates.
   and evaluation gates.
 - `harness-contract.schema.json` defines the benchmark harness that decides
   whether a workflow contract is harnessed, verified, or promotable.
+- `benchmark-kind.schema.json` is the canonical enum for benchmark gate
+  identifiers shared by workflow and harness contracts.
 - `examples/standard-orchestration-workflow.contract.json` is the reference
   workflow contract for the existing `DurableWorkflowEngine` surface.
 - `examples/standard-orchestration-harness.contract.json` binds the workflow to
@@ -31,7 +49,7 @@ actionable:
 | Failure injection and recovery | Benchmark 3 | correct final state and complete audit trail |
 | MAKER long-horizon execution | `MakerBenchmark` | at least 10 discs completed |
 
-Promotion from `specified` to `verified` requires all critical gates to pass and
-evidence artifacts to be attached to the task or release record. The schemas do
-not claim a workflow is currently verified; they define the contract required to
-produce that evidence.
+Promotion from `specified` to `verified` is not automated yet. It requires all
+critical gates to pass and evidence artifacts to be attached to the task or
+release record. The schemas do not claim a workflow is currently verified; they
+define the contract required to produce that evidence.

--- a/docs/spec/agent-contracts/benchmark-kind.schema.json
+++ b/docs/spec/agent-contracts/benchmark-kind.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cognitive-mesh.local/schemas/agent-contracts/benchmark-kind.schema.json",
+  "title": "Cognitive Mesh Benchmark Kind",
+  "description": "Canonical benchmark gate identifiers used by workflow and harness contracts.",
+  "enum": [
+    "interactive-coordination-latency",
+    "parallel-fanout-throughput",
+    "failure-injection-recovery",
+    "maker-long-horizon"
+  ]
+}

--- a/docs/spec/agent-contracts/examples/standard-orchestration-harness.contract.json
+++ b/docs/spec/agent-contracts/examples/standard-orchestration-harness.contract.json
@@ -81,7 +81,7 @@
         "backpressureProbe": "2x saturation point"
       },
       "measurements": [
-        "wall_clock_ms",
+        "n100_wall_clock_ms",
         "tasks_per_second",
         "memory_peak_mb",
         "saturation_point",

--- a/docs/spec/agent-contracts/examples/standard-orchestration-harness.contract.json
+++ b/docs/spec/agent-contracts/examples/standard-orchestration-harness.contract.json
@@ -1,0 +1,214 @@
+{
+  "schemaVersion": "agent-harness-contract/v1",
+  "contractId": "cognitive-mesh.standard-orchestration-harness.v1",
+  "workflowContractRef": "docs/spec/agent-contracts/examples/standard-orchestration-workflow.contract.json",
+  "owner": {
+    "repo": "phoenixvc/cognitive-mesh",
+    "team": "AgencyLayer",
+    "batonTaskId": "1ec54695-abd3-4bd7-b03e-53ed5f19133f"
+  },
+  "environment": {
+    "runtime": ".NET DurableWorkflowEngine benchmark runner",
+    "clock": "monotonic",
+    "warmupIterations": 100,
+    "resourceTelemetry": [
+      "cpu",
+      "memory",
+      "queue-depth",
+      "tokens",
+      "cost"
+    ]
+  },
+  "benchmarks": [
+    {
+      "benchmarkId": "interactive-coordination-latency",
+      "kind": "interactive-coordination-latency",
+      "description": "Measures p95 time from request arrival to first meaningful agent acknowledgement.",
+      "workload": {
+        "iterations": 1000,
+        "discardWarmupIterations": 100,
+        "input": {
+          "taskId": "latency-sample",
+          "agentCount": 3,
+          "payload": "classify"
+        }
+      },
+      "measurements": [
+        "p50_ms",
+        "p95_ms",
+        "p99_ms",
+        "parse_ms",
+        "routing_ms",
+        "dispatch_ms"
+      ],
+      "gates": [
+        {
+          "gateId": "latency-acceptable-p95",
+          "critical": true,
+          "metric": "p95_ms",
+          "operator": "<",
+          "threshold": 200,
+          "rating": 3,
+          "source": "docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md"
+        },
+        {
+          "gateId": "latency-good-p95",
+          "critical": false,
+          "metric": "p95_ms",
+          "operator": "<",
+          "threshold": 50,
+          "rating": 4,
+          "source": "docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md"
+        }
+      ]
+    },
+    {
+      "benchmarkId": "parallel-fanout-throughput",
+      "kind": "parallel-fanout-throughput",
+      "description": "Measures fan-out/fan-in throughput and validates backpressure under saturation.",
+      "workload": {
+        "batchSizes": [
+          1,
+          5,
+          10,
+          25,
+          50,
+          100,
+          250,
+          500
+        ],
+        "simulatedOperationMs": 100,
+        "backpressureProbe": "2x saturation point"
+      },
+      "measurements": [
+        "wall_clock_ms",
+        "tasks_per_second",
+        "memory_peak_mb",
+        "saturation_point",
+        "backpressure_observed"
+      ],
+      "gates": [
+        {
+          "gateId": "fanout-acceptable-n100-wallclock",
+          "critical": true,
+          "metric": "n100_wall_clock_ms",
+          "operator": "<",
+          "threshold": 30000,
+          "rating": 3,
+          "source": "docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md"
+        },
+        {
+          "gateId": "fanout-backpressure-observed",
+          "critical": true,
+          "metric": "backpressure_observed",
+          "operator": "==",
+          "threshold": true,
+          "rating": 3,
+          "source": "docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md"
+        }
+      ]
+    },
+    {
+      "benchmarkId": "failure-injection-recovery",
+      "kind": "failure-injection-recovery",
+      "description": "Validates retry behavior, timeout handling, permanent failure reporting, and audit completeness.",
+      "workload": {
+        "taskCount": 10,
+        "failureRate": 0.3,
+        "expectedSucceeded": 9,
+        "expectedPermanentFailures": 1
+      },
+      "measurements": [
+        "time_to_first_retry_ms",
+        "total_retries",
+        "permanent_failure_detection_ms",
+        "timeout_detection_ms",
+        "correct_final_state",
+        "audit_trail_complete"
+      ],
+      "gates": [
+        {
+          "gateId": "failure-final-state-correct",
+          "critical": true,
+          "metric": "correct_final_state",
+          "operator": "==",
+          "threshold": true,
+          "rating": 3,
+          "source": "docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md"
+        },
+        {
+          "gateId": "failure-audit-complete",
+          "critical": true,
+          "metric": "audit_trail_complete",
+          "operator": "==",
+          "threshold": true,
+          "rating": 3,
+          "source": "docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md"
+        }
+      ],
+      "failureTypes": [
+        "transient",
+        "permanent",
+        "timeout",
+        "cascade"
+      ]
+    },
+    {
+      "benchmarkId": "maker-long-horizon",
+      "kind": "maker-long-horizon",
+      "description": "Uses the existing Tower of Hanoi MAKER benchmark to gate long-horizon sequential workflow execution.",
+      "workload": {
+        "runner": "AgencyLayer.Orchestration.Benchmarks.MakerBenchmark.RunProgressiveBenchmarkAsync",
+        "minimumDiscsCompleted": 10,
+        "targetDiscsCompleted": 15
+      },
+      "measurements": [
+        "max_discs_completed",
+        "max_steps_completed",
+        "overall_maker_score",
+        "checkpoints_created"
+      ],
+      "gates": [
+        {
+          "gateId": "maker-minimum-10-discs",
+          "critical": true,
+          "metric": "max_discs_completed",
+          "operator": ">=",
+          "threshold": 10,
+          "rating": 3,
+          "source": "src/AgencyLayer/Orchestration/Benchmarks/MakerBenchmark.cs"
+        },
+        {
+          "gateId": "maker-target-15-discs",
+          "critical": false,
+          "metric": "max_discs_completed",
+          "operator": ">=",
+          "threshold": 15,
+          "rating": 5,
+          "source": "src/AgencyLayer/Orchestration/Benchmarks/MakerBenchmark.cs"
+        }
+      ]
+    }
+  ],
+  "reporting": {
+    "format": "markdown",
+    "artifactPath": "docs/orchestration-evaluation/08-gaps-and-future/benchmark-results/",
+    "requiredSections": [
+      "environment",
+      "interactive coordination latency",
+      "fan-out throughput",
+      "failure recovery",
+      "maker long-horizon",
+      "promotion decision"
+    ]
+  },
+  "promotion": {
+    "minimumLifecycleState": "verified",
+    "allCriticalGatesMustPass": true,
+    "evidenceRefs": [
+      "docs/orchestration-evaluation/08-gaps-and-future/benchmark-harness-spec.md",
+      "tests/AgencyLayer/Orchestration/Benchmarks/MakerBenchmarkTests.cs",
+      "tests/AgencyLayer/Orchestration/Benchmarks/ExecutionPipelineGapAnalysisTests.cs"
+    ]
+  }
+}

--- a/docs/spec/agent-contracts/examples/standard-orchestration-workflow.contract.json
+++ b/docs/spec/agent-contracts/examples/standard-orchestration-workflow.contract.json
@@ -1,0 +1,288 @@
+{
+  "schemaVersion": "agent-workflow-contract/v1",
+  "contractId": "cognitive-mesh.standard-orchestration.v1",
+  "name": "Standard governed orchestration workflow",
+  "description": "Reference workflow contract for the Agent Operating Model v0 Cognitive Mesh runtime surface.",
+  "sourceAdr": "org-meta/architecture/agent-operating-model.md",
+  "lifecycleState": "specified",
+  "owner": {
+    "repo": "phoenixvc/cognitive-mesh",
+    "team": "AgencyLayer",
+    "batonTaskId": "1ec54695-abd3-4bd7-b03e-53ed5f19133f"
+  },
+  "trigger": {
+    "type": "api",
+    "entrypoint": "AgencyLayer.Orchestration.Execution.IWorkflowEngine.ExecuteWorkflowAsync",
+    "idempotencyKey": "$.taskId",
+    "preconditions": [
+      "caller has workflow.execute authority",
+      "input validates against contract input schema"
+    ]
+  },
+  "input": {
+    "contentType": "application/json",
+    "schema": {
+      "type": "object",
+      "required": [
+        "taskId",
+        "payload"
+      ],
+      "properties": {
+        "taskId": {
+          "type": "string"
+        },
+        "payload": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "taskId": "demo-001",
+        "payload": {
+          "type": "classify"
+        }
+      }
+    ]
+  },
+  "output": {
+    "contentType": "application/json",
+    "schema": {
+      "type": "object",
+      "required": [
+        "workflowId",
+        "success",
+        "auditEventCount"
+      ],
+      "properties": {
+        "workflowId": {
+          "type": "string"
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "auditEventCount": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "steps": [
+    {
+      "stepId": "validate-input",
+      "order": 0,
+      "name": "Validate request",
+      "kind": "validate",
+      "inputRef": "$.input",
+      "outputRef": "$.state.validatedInput",
+      "stateWrites": [
+        "validatedInput"
+      ],
+      "dependsOn": [],
+      "authorityScope": "workflow.validate",
+      "tools": [],
+      "modelRoute": {
+        "routingPolicyRef": "none",
+        "providerPolicy": "none",
+        "modelClass": "none"
+      },
+      "costRoute": {
+        "costCenter": "cognitive-mesh",
+        "usageMeter": "docket.workflow.validation",
+        "budgetCapUsd": 0,
+        "docketRouteRef": "pending-docket-canonical-url"
+      },
+      "timeoutMs": 1000,
+      "retry": {
+        "maxAttempts": 0,
+        "strategy": "none"
+      },
+      "backpressure": {
+        "maxConcurrency": 100,
+        "queuePolicy": "reject",
+        "queueLimit": 0
+      },
+      "idempotency": {
+        "keyRef": "$.taskId",
+        "effect": "read-only"
+      },
+      "auditEvents": [
+        "workflow.input.validated"
+      ]
+    },
+    {
+      "stepId": "route-agent",
+      "order": 1,
+      "name": "Route to agent",
+      "kind": "route",
+      "inputRef": "$.state.validatedInput",
+      "outputRef": "$.state.route",
+      "stateWrites": [
+        "route"
+      ],
+      "dependsOn": [
+        "validate-input"
+      ],
+      "authorityScope": "workflow.route",
+      "tools": [
+        {
+          "toolId": "AgencyLayer.AgencyRouter.TaskRouter",
+          "mode": "execute",
+          "required": true
+        }
+      ],
+      "modelRoute": {
+        "routingPolicyRef": "sluice.policy.standard-orchestration",
+        "providerPolicy": "gateway-managed",
+        "modelClass": "fast",
+        "maxTokens": 2048
+      },
+      "costRoute": {
+        "costCenter": "cognitive-mesh",
+        "usageMeter": "docket.workflow.routing",
+        "budgetCapUsd": 0.05,
+        "docketRouteRef": "pending-docket-canonical-url"
+      },
+      "timeoutMs": 5000,
+      "retry": {
+        "maxAttempts": 1,
+        "strategy": "fixed",
+        "baseDelayMs": 100
+      },
+      "backpressure": {
+        "maxConcurrency": 25,
+        "queuePolicy": "queue",
+        "queueLimit": 100
+      },
+      "idempotency": {
+        "keyRef": "$.taskId",
+        "effect": "dedupe"
+      },
+      "auditEvents": [
+        "workflow.agent.routed",
+        "workflow.model.route.selected",
+        "workflow.cost.usage.estimated"
+      ]
+    },
+    {
+      "stepId": "aggregate-result",
+      "order": 2,
+      "name": "Aggregate result",
+      "kind": "aggregate",
+      "inputRef": "$.state.route",
+      "outputRef": "$.output",
+      "stateWrites": [
+        "finalResult"
+      ],
+      "dependsOn": [
+        "route-agent"
+      ],
+      "authorityScope": "workflow.aggregate",
+      "tools": [],
+      "modelRoute": {
+        "routingPolicyRef": "none",
+        "providerPolicy": "none",
+        "modelClass": "none"
+      },
+      "costRoute": {
+        "costCenter": "cognitive-mesh",
+        "usageMeter": "docket.workflow.aggregate",
+        "budgetCapUsd": 0,
+        "docketRouteRef": "pending-docket-canonical-url"
+      },
+      "timeoutMs": 1000,
+      "retry": {
+        "maxAttempts": 0,
+        "strategy": "none"
+      },
+      "backpressure": {
+        "maxConcurrency": 100,
+        "queuePolicy": "reject",
+        "queueLimit": 0
+      },
+      "idempotency": {
+        "keyRef": "$.taskId",
+        "effect": "read-only"
+      },
+      "auditEvents": [
+        "workflow.result.aggregated"
+      ]
+    }
+  ],
+  "stateHandoff": {
+    "store": "checkpoint-manager",
+    "checkpointPolicy": "per-step",
+    "handoffKeys": [
+      "validatedInput",
+      "route",
+      "finalResult"
+    ],
+    "retentionDays": 30
+  },
+  "authority": {
+    "defaultScope": "workflow.execute",
+    "restrictedScopes": [
+      "filesystem.write",
+      "external.write",
+      "deployment.write"
+    ],
+    "escalationPolicy": "human-approval"
+  },
+  "runtime": {
+    "engine": "DurableWorkflowEngine",
+    "timeoutMs": 60000,
+    "defaultRetry": {
+      "maxAttempts": 3,
+      "strategy": "exponential",
+      "baseDelayMs": 250
+    },
+    "defaultBackpressure": {
+      "maxConcurrency": 25,
+      "queuePolicy": "queue",
+      "queueLimit": 100
+    }
+  },
+  "approval": {
+    "mode": "policy-gated",
+    "gates": [
+      {
+        "gateId": "restricted-tool-use",
+        "condition": "step authority scope is restricted",
+        "approver": "workflow.policy"
+      }
+    ]
+  },
+  "audit": {
+    "eventSchema": "docs/spec/agent-contracts/workflow-audit-event.v1",
+    "requiredEvents": [
+      "workflow.input.validated",
+      "workflow.agent.routed",
+      "workflow.result.aggregated"
+    ],
+    "tracePropagation": "baton-trace"
+  },
+  "rollback": {
+    "strategy": "checkpoint-restore",
+    "steps": [
+      "restore latest successful checkpoint",
+      "emit workflow.rollback.completed audit event"
+    ],
+    "verification": "GetWorkflowStatusAsync returns Suspended, Failed, or Completed with auditable final state"
+  },
+  "evaluation": {
+    "harnessContractRef": "docs/spec/agent-contracts/examples/standard-orchestration-harness.contract.json",
+    "requiredGates": [
+      "interactive-coordination-latency",
+      "parallel-fanout-throughput",
+      "failure-injection-recovery",
+      "maker-long-horizon"
+    ],
+    "promotionRule": "Lifecycle may advance to verified only when all critical harness gates pass and evidence artifacts are attached."
+  },
+  "metadata": {
+    "parentEpic": "e1c82235-02d8-4b99-ba86-da2195271845"
+  }
+}

--- a/docs/spec/agent-contracts/examples/standard-orchestration-workflow.contract.json
+++ b/docs/spec/agent-contracts/examples/standard-orchestration-workflow.contract.json
@@ -126,7 +126,7 @@
       "dependsOn": [
         "validate-input"
       ],
-      "authorityScope": "workflow.route",
+      "authorityScope": "external.write",
       "tools": [
         {
           "toolId": "AgencyLayer.AgencyRouter.TaskRouter",

--- a/docs/spec/agent-contracts/harness-contract.schema.json
+++ b/docs/spec/agent-contracts/harness-contract.schema.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cognitive-mesh.local/schemas/agent-contracts/harness-contract.schema.json",
+  "title": "Cognitive Mesh Harness Contract",
+  "description": "Machine-readable contract for workflow evaluation harnesses and benchmark gates.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "contractId",
+    "workflowContractRef",
+    "owner",
+    "environment",
+    "benchmarks",
+    "reporting",
+    "promotion"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "agent-harness-contract/v1"
+    },
+    "contractId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"
+    },
+    "workflowContractRef": {
+      "type": "string",
+      "minLength": 1
+    },
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repo",
+        "team"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "team": {
+          "type": "string",
+          "minLength": 1
+        },
+        "batonTaskId": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "runtime",
+        "clock",
+        "warmupIterations"
+      ],
+      "properties": {
+        "runtime": {
+          "type": "string",
+          "minLength": 1
+        },
+        "clock": {
+          "enum": [
+            "monotonic",
+            "wall"
+          ]
+        },
+        "warmupIterations": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resourceTelemetry": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "cpu",
+              "memory",
+              "queue-depth",
+              "tokens",
+              "cost"
+            ]
+          }
+        }
+      }
+    },
+    "benchmarks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/benchmark"
+      }
+    },
+    "reporting": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format",
+        "requiredSections",
+        "artifactPath"
+      ],
+      "properties": {
+        "format": {
+          "enum": [
+            "markdown",
+            "json",
+            "junit"
+          ]
+        },
+        "artifactPath": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requiredSections": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "promotion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "minimumLifecycleState",
+        "allCriticalGatesMustPass",
+        "evidenceRefs"
+      ],
+      "properties": {
+        "minimumLifecycleState": {
+          "enum": [
+            "harnessed",
+            "verified",
+            "promoted"
+          ]
+        },
+        "allCriticalGatesMustPass": {
+          "type": "boolean"
+        },
+        "evidenceRefs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "benchmark": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "benchmarkId",
+        "kind",
+        "description",
+        "workload",
+        "measurements",
+        "gates"
+      ],
+      "properties": {
+        "benchmarkId": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"
+        },
+        "kind": {
+          "enum": [
+            "interactive-coordination-latency",
+            "parallel-fanout-throughput",
+            "failure-injection-recovery",
+            "maker-long-horizon"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "workload": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "measurements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "gates": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/gate"
+          }
+        },
+        "failureTypes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "transient",
+              "permanent",
+              "timeout",
+              "cascade"
+            ]
+          }
+        }
+      }
+    },
+    "gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gateId",
+        "critical",
+        "metric",
+        "operator",
+        "threshold",
+        "rating"
+      ],
+      "properties": {
+        "gateId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "critical": {
+          "type": "boolean"
+        },
+        "metric": {
+          "type": "string",
+          "minLength": 1
+        },
+        "operator": {
+          "enum": [
+            "<",
+            "<=",
+            ">",
+            ">=",
+            "==",
+            "contains"
+          ]
+        },
+        "threshold": {
+          "type": [
+            "number",
+            "integer",
+            "string",
+            "boolean"
+          ]
+        },
+        "rating": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 5
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/spec/agent-contracts/harness-contract.schema.json
+++ b/docs/spec/agent-contracts/harness-contract.schema.json
@@ -168,12 +168,7 @@
           "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"
         },
         "kind": {
-          "enum": [
-            "interactive-coordination-latency",
-            "parallel-fanout-throughput",
-            "failure-injection-recovery",
-            "maker-long-horizon"
-          ]
+          "$ref": "benchmark-kind.schema.json"
         },
         "description": {
           "type": "string",

--- a/docs/spec/agent-contracts/workflow-contract.schema.json
+++ b/docs/spec/agent-contracts/workflow-contract.schema.json
@@ -316,10 +316,12 @@
           "$ref": "#/$defs/idempotency"
         },
         "approvalGateId": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "rollbackStepId": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "auditEvents": {
           "type": "array",

--- a/docs/spec/agent-contracts/workflow-contract.schema.json
+++ b/docs/spec/agent-contracts/workflow-contract.schema.json
@@ -1,0 +1,674 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cognitive-mesh.local/schemas/agent-contracts/workflow-contract.schema.json",
+  "title": "Cognitive Mesh Workflow Contract",
+  "description": "Machine-readable contract for a governed multi-agent workflow owned by Cognitive Mesh.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "contractId",
+    "lifecycleState",
+    "owner",
+    "trigger",
+    "input",
+    "steps",
+    "stateHandoff",
+    "authority",
+    "runtime",
+    "approval",
+    "audit",
+    "rollback",
+    "evaluation"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "agent-workflow-contract/v1"
+    },
+    "contractId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "sourceAdr": {
+      "type": "string",
+      "description": "Repository-relative pointer to the source ADR or operating-model decision."
+    },
+    "lifecycleState": {
+      "enum": [
+        "proposed",
+        "specified",
+        "harnessed",
+        "verified",
+        "promoted",
+        "restricted",
+        "retired"
+      ]
+    },
+    "owner": {
+      "$ref": "#/$defs/owner"
+    },
+    "trigger": {
+      "$ref": "#/$defs/trigger"
+    },
+    "input": {
+      "$ref": "#/$defs/ioSchema"
+    },
+    "output": {
+      "$ref": "#/$defs/ioSchema"
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/step"
+      }
+    },
+    "stateHandoff": {
+      "$ref": "#/$defs/stateHandoff"
+    },
+    "authority": {
+      "$ref": "#/$defs/authority"
+    },
+    "runtime": {
+      "$ref": "#/$defs/runtime"
+    },
+    "approval": {
+      "$ref": "#/$defs/approval"
+    },
+    "audit": {
+      "$ref": "#/$defs/audit"
+    },
+    "rollback": {
+      "$ref": "#/$defs/rollback"
+    },
+    "evaluation": {
+      "$ref": "#/$defs/evaluation"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "string",
+          "number",
+          "boolean",
+          "null"
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repo",
+        "team"
+      ],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "team": {
+          "type": "string",
+          "minLength": 1
+        },
+        "batonTaskId": {
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    },
+    "trigger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "entrypoint",
+        "idempotencyKey"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "manual",
+            "api",
+            "event",
+            "schedule",
+            "baton-task",
+            "github-workflow"
+          ]
+        },
+        "entrypoint": {
+          "type": "string",
+          "minLength": 1
+        },
+        "idempotencyKey": {
+          "type": "string",
+          "minLength": 1
+        },
+        "preconditions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ioSchema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contentType",
+        "schema"
+      ],
+      "properties": {
+        "contentType": {
+          "enum": [
+            "application/json",
+            "text/plain"
+          ]
+        },
+        "schema": {
+          "type": "object",
+          "description": "Inline JSON Schema fragment for this workflow boundary."
+        },
+        "examples": {
+          "type": "array",
+          "items": {}
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stepId",
+        "order",
+        "name",
+        "kind",
+        "inputRef",
+        "outputRef",
+        "authorityScope",
+        "tools",
+        "modelRoute",
+        "costRoute",
+        "timeoutMs",
+        "retry",
+        "backpressure",
+        "idempotency",
+        "auditEvents"
+      ],
+      "properties": {
+        "stepId": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9._-]{1,63}$"
+        },
+        "order": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "enum": [
+            "validate",
+            "route",
+            "reason",
+            "tool-call",
+            "human-approval",
+            "aggregate",
+            "rollback",
+            "emit-audit"
+          ]
+        },
+        "inputRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outputRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stateWrites": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "authorityScope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolRef"
+          }
+        },
+        "modelRoute": {
+          "$ref": "#/$defs/modelRoute"
+        },
+        "costRoute": {
+          "$ref": "#/$defs/costRoute"
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "retry": {
+          "$ref": "#/$defs/retry"
+        },
+        "backpressure": {
+          "$ref": "#/$defs/backpressure"
+        },
+        "idempotency": {
+          "$ref": "#/$defs/idempotency"
+        },
+        "approvalGateId": {
+          "type": "string"
+        },
+        "rollbackStepId": {
+          "type": "string"
+        },
+        "auditEvents": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "toolRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "toolId",
+        "mode"
+      ],
+      "properties": {
+        "toolId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mode": {
+          "enum": [
+            "read",
+            "write",
+            "execute",
+            "mocked"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "modelRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "routingPolicyRef",
+        "providerPolicy"
+      ],
+      "properties": {
+        "routingPolicyRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "providerPolicy": {
+          "enum": [
+            "fixed",
+            "fallback",
+            "gateway-managed",
+            "none"
+          ]
+        },
+        "modelClass": {
+          "enum": [
+            "none",
+            "fast",
+            "balanced",
+            "reasoning",
+            "embedding"
+          ]
+        },
+        "maxTokens": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "costRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "costCenter",
+        "usageMeter",
+        "budgetCapUsd"
+      ],
+      "properties": {
+        "costCenter": {
+          "type": "string",
+          "minLength": 1
+        },
+        "usageMeter": {
+          "type": "string",
+          "minLength": 1
+        },
+        "budgetCapUsd": {
+          "type": "number",
+          "minimum": 0
+        },
+        "docketRouteRef": {
+          "type": "string"
+        }
+      }
+    },
+    "retry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "maxAttempts",
+        "strategy"
+      ],
+      "properties": {
+        "maxAttempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "strategy": {
+          "enum": [
+            "none",
+            "fixed",
+            "exponential"
+          ]
+        },
+        "baseDelayMs": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "backpressure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "maxConcurrency",
+        "queuePolicy"
+      ],
+      "properties": {
+        "maxConcurrency": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "queuePolicy": {
+          "enum": [
+            "reject",
+            "queue",
+            "shed-low-priority"
+          ]
+        },
+        "queueLimit": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keyRef",
+        "effect"
+      ],
+      "properties": {
+        "keyRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "effect": {
+          "enum": [
+            "read-only",
+            "dedupe",
+            "exactly-once-required"
+          ]
+        }
+      }
+    },
+    "stateHandoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "store",
+        "checkpointPolicy",
+        "handoffKeys"
+      ],
+      "properties": {
+        "store": {
+          "enum": [
+            "in-memory",
+            "checkpoint-manager",
+            "durable-store",
+            "external"
+          ]
+        },
+        "checkpointPolicy": {
+          "enum": [
+            "none",
+            "per-step",
+            "per-stage",
+            "on-state-change"
+          ]
+        },
+        "handoffKeys": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "retentionDays": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "defaultScope",
+        "escalationPolicy"
+      ],
+      "properties": {
+        "defaultScope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "restrictedScopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "escalationPolicy": {
+          "enum": [
+            "deny",
+            "human-approval",
+            "service-policy"
+          ]
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "engine",
+        "timeoutMs",
+        "defaultRetry",
+        "defaultBackpressure"
+      ],
+      "properties": {
+        "engine": {
+          "enum": [
+            "DurableWorkflowEngine",
+            "MultiAgentOrchestrationEngine",
+            "external"
+          ]
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "defaultRetry": {
+          "$ref": "#/$defs/retry"
+        },
+        "defaultBackpressure": {
+          "$ref": "#/$defs/backpressure"
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "gates"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "pre-approved",
+            "policy-gated",
+            "human-gated",
+            "disabled"
+          ]
+        },
+        "gates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "gateId",
+              "condition",
+              "approver"
+            ],
+            "properties": {
+              "gateId": {
+                "type": "string"
+              },
+              "condition": {
+                "type": "string"
+              },
+              "approver": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "eventSchema",
+        "requiredEvents"
+      ],
+      "properties": {
+        "eventSchema": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requiredEvents": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "tracePropagation": {
+          "enum": [
+            "w3c",
+            "baton-trace",
+            "none"
+          ]
+        }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strategy",
+        "steps"
+      ],
+      "properties": {
+        "strategy": {
+          "enum": [
+            "none",
+            "compensating-steps",
+            "checkpoint-restore",
+            "manual"
+          ]
+        },
+        "steps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "verification": {
+          "type": "string"
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "harnessContractRef",
+        "requiredGates"
+      ],
+      "properties": {
+        "harnessContractRef": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requiredGates": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "enum": [
+              "interactive-coordination-latency",
+              "parallel-fanout-throughput",
+              "failure-injection-recovery",
+              "maker-long-horizon"
+            ]
+          }
+        },
+        "promotionRule": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/spec/agent-contracts/workflow-contract.schema.json
+++ b/docs/spec/agent-contracts/workflow-contract.schema.json
@@ -188,6 +188,42 @@
     "step": {
       "type": "object",
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "human-approval"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "required": [
+              "approvalGateId"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "rollback"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "required": [
+              "rollbackStepId"
+            ]
+          }
+        }
+      ],
       "required": [
         "stepId",
         "order",
@@ -657,12 +693,7 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "enum": [
-              "interactive-coordination-latency",
-              "parallel-fanout-throughput",
-              "failure-injection-recovery",
-              "maker-long-horizon"
-            ]
+            "$ref": "benchmark-kind.schema.json"
           }
         },
         "promotionRule": {


### PR DESCRIPTION
## Summary

Adds the Cognitive Mesh side of Agent Operating Model v0 as machine-readable documentation contracts:

- `workflow-contract.schema.json` for governed workflow boundaries: trigger/input, ordered steps, state handoff, authority, tools, model route, cost route, timeout/retry/backpressure/idempotency, approval, audit, rollback, and evaluation gates.
- `harness-contract.schema.json` for benchmark harness gates.
- Reference workflow and harness examples for the existing `DurableWorkflowEngine` surface.
- README links from `docs/spec` and `docs/orchestration-evaluation`.

## Why

Baton task `1ec54695-abd3-4bd7-b03e-53ed5f19133f` needs Cognitive Mesh to own runtime workflow/harness schemas and tie them to benchmark gates before downstream Retort/Baton/Sluice/Docket rollout work can consume stable contracts.

## Validation

- JSON syntax validation with PowerShell `ConvertFrom-Json`
- AJV 2020 validation of examples against both schemas
- `dotnet build CognitiveMesh.sln` passed with 0 warnings
- `dotnet test CognitiveMesh.sln --no-build` passed 581 tests

## Notes

This is docs/spec work only. Existing unrelated untracked local files were not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the spec docs with a new “Agent Contract Gates” section describing the benchmark harness contract surface and lifecycle expectations.
  * Added guidance for gate-based evaluation, including latency, fan-out throughput, failure recovery, and long-horizon criteria.
  * Documented that promotion from specified to verified is not automated and requires manual gate runs and evidence attachment.
* **New Specifications**
  * Added machine-readable JSON Schemas for workflow and harness contracts, plus a benchmark-kind enum.
  * Included standard-orchestration workflow and harness contract example bindings with reporting and promotion thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->