### PR TITLE
chore: clean untracked artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ msbuild.wrn
 
 # Build artifacts folder
 build/
+publish/
+publish-fd/
 
 # Visual Studio files
 .vs/

--- a/CognitiveMesh.sln
+++ b/CognitiveMesh.sln
@@ -103,6 +103,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PolicyStore.Tests", "tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SelfHealing.Tests", "tests\AgencyLayer\SelfHealing\SelfHealing.Tests.csproj", "{A0B1C2D3-E4F5-6789-ABCD-100000000005}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CognitiveMesh", "src\BusinessApplications\CognitiveMesh\CognitiveMesh.csproj", "{A96A96DB-ACD6-422B-B19F-3438BF691F1B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -617,6 +619,18 @@ Global
 		{A0B1C2D3-E4F5-6789-ABCD-100000000005}.Release|x64.Build.0 = Release|Any CPU
 		{A0B1C2D3-E4F5-6789-ABCD-100000000005}.Release|x86.ActiveCfg = Release|Any CPU
 		{A0B1C2D3-E4F5-6789-ABCD-100000000005}.Release|x86.Build.0 = Release|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Debug|x64.Build.0 = Debug|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Debug|x86.Build.0 = Debug|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Release|x64.ActiveCfg = Release|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Release|x64.Build.0 = Release|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Release|x86.ActiveCfg = Release|Any CPU
+		{A96A96DB-ACD6-422B-B19F-3438BF691F1B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BusinessApplications/CognitiveMesh/CognitiveMesh.csproj
+++ b/src/BusinessApplications/CognitiveMesh/CognitiveMesh.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>CognitiveMesh.BusinessApplications.CognitiveMesh</AssemblyName>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\FoundationLayer\FoundationLayer.csproj" />
+    <ProjectReference Include="..\..\AgencyLayer\AgencyLayer.csproj" />
+    <ProjectReference Include="..\..\ReasoningLayer\AgencyRouter\AgencyRouter.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Cleans up the pre-existing untracked workspace files found after PR #521:

- removes stale local/generated workspace artifacts from the checkout (`publish/`, `publish-fd/`, `.roadmap.yaml`, `.todo.yaml`, `Dockerfile.api`)
- adds `publish/` and `publish-fd/` to `.gitignore`
- adds the content-bearing `src/BusinessApplications/CognitiveMesh/CognitiveMesh.csproj`
- wires that project into `CognitiveMesh.sln` so the tracked CognitiveMesh controller/infrastructure files compile in the solution

## Validation

- `dotnet build src\BusinessApplications\CognitiveMesh\CognitiveMesh.csproj` passed with 0 warnings
- `dotnet build CognitiveMesh.sln` passed with 0 warnings
- `dotnet test CognitiveMesh.sln --no-build` passed 581 tests

## Baton

Baton task: `62d891d0-4516-43bf-8117-6912355f7144`