### PR TITLE
docs: record NeuralLiquid OIDC readiness

### DIFF
--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -191,6 +191,14 @@ Current production behavior:
 - Docket usage-ingestion smoke succeeded through CogMesh production:
   - `POST https://api.cognitivemesh.neuralliquid.ai/api/v1/docket/usage` returned HTTP 202 for correlation `codex-smoke-20260714134919`.
   - Docket production Container App logs show `POST /usage/model-events HTTP/1.1` returned `200 OK` at `2026-07-14T11:49:50Z`.
+- NeuralLiquid GitHub Actions OIDC federated credentials were added to Entra app registration `nl-cognitive-mesh-github-actions`:
+  - `repo:neuralliquid/cognitive-mesh:ref:refs/heads/dev`
+  - `repo:neuralliquid/cognitive-mesh:ref:refs/heads/main`
+  - `repo:neuralliquid/cognitive-mesh:environment:production`
+- Source repo transfer settings snapshot:
+  - Variables present on `phoenixvc/cognitive-mesh`: `AZURE_WEBAPP_RESOURCE_GROUP`, `COGMESH_DOCKET_BASE_URL`, `COGMESH_SLUICE_API_KEY_SECRET_URI`, `COGMESH_SLUICE_BASE_URL`, `COGMESH_SLUICE_MAX_TOKENS`, `COGMESH_SLUICE_MODEL`, `COGNITIVE_MESH_API_APP_NAME`, `COGNITIVE_MESH_FRONTEND_APP_NAME`, `NEXT_PUBLIC_MYSTIRA_AUTH_CLIENT_ID`, `NEXT_PUBLIC_MYSTIRA_TENANT_ID`.
+  - Secrets present on `phoenixvc/cognitive-mesh`: `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `COGMESH_DOCKET_API_KEY`, `SONAR_HOST_URL`, `SONAR_TOKEN`.
+- `neuralliquid/cognitive-mesh` does not currently exist, so target-repo variables, secrets, environments, app installations, and DNS/custom-domain ownership must be validated after the actual GitHub repository transfer.
 - Durability note: Terraform full apply still needs review because existing App Service drift can affect frontend settings and image tags, but Sluice secret wiring now uses the preferred Key Vault reference path.
 
 ## Transfer Baseline Refresh - 2026-07-13

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -137,12 +137,19 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Removed the temporary direct `COGMESH_SLUICE_API_KEY` GitHub secret after Key Vault wiring was in place.
 - Rotated the Sluice gateway key on 2026-07-14 after an app-setting value query exposed the previous value in local tool output.
 - Verified Azure config-reference status for production and staging `SLUICE_API_KEY` is `Resolved`.
+- Added NeuralLiquid GitHub Actions OIDC federated credential subjects to Entra app registration `nl-cognitive-mesh-github-actions`:
+  - `repo:neuralliquid/cognitive-mesh:ref:refs/heads/dev`
+  - `repo:neuralliquid/cognitive-mesh:ref:refs/heads/main`
+  - `repo:neuralliquid/cognitive-mesh:environment:production`
+- Verified both PhoenixVC and NeuralLiquid federated subjects are present on the deployment identity.
+- Verified `neuralliquid/cognitive-mesh` currently returns GitHub HTTP 404, so target-repository settings cannot be validated until the repository is transferred.
+- Captured current source repository variable and secret names for transfer validation; no secret values were recorded.
 
 ## Remaining Before Transfer
 
 1. Publish and merge the deploy-workflow durability patch that keeps the Sluice Key Vault URI path and optional direct-secret fallback.
 2. Baton Migration Coordinator: reconcile frontend App Service Terraform drift before any full prod apply.
-3. Baton Migration Coordinator: add `neuralliquid/cognitive-mesh` OIDC federated credential subjects or create a NeuralLiquid-owned deployment identity.
+3. Baton Migration Coordinator: perform the actual GitHub repository transfer to `neuralliquid/cognitive-mesh` once approved.
 4. Baton Migration Coordinator: recreate/validate repository variables, secrets, environments, app installations, and DNS/custom-domain ownership after transfer.
 5. Baton FinOps and Runway Analyst: verify Docket-backed cost-attribution readiness from the Sluice-routed CogMesh usage path before using the transfer as funding evidence.
 6. Baton Evidence and Claims Auditor: validate that public migration/funding claims distinguish implemented Sluice/Docket routing from remaining transfer prerequisites.


### PR DESCRIPTION
## Summary
- record that NeuralLiquid GitHub Actions OIDC subjects were added to nl-cognitive-mesh-github-actions
- capture current source repo variable and secret names for post-transfer validation
- clarify that neuralliquid/cognitive-mesh currently returns 404, so target-repo settings validation is blocked until the actual transfer

## Changes
- updates NeuralLiquid migration handoff and verification docs only
- marks OIDC subject creation complete
- keeps remaining Baton Migration Coordinator gates focused on transfer, repo settings, app installations, and DNS/custom-domain ownership

## Related Issues
- NeuralLiquid Cognitive Mesh migration / Batch 2 closeout

## Architecture Layer
- Migration documentation only

## Checklist
- [x] Verified PhoenixVC and NeuralLiquid OIDC subjects are present
- [x] Verified target repo does not exist yet
- [x] Recorded source repo variable and secret names without secret values

## Test Plan
- git diff --check
- az ad app federated-credential list for nl-cognitive-mesh-github-actions
- gh api repos/neuralliquid/cognitive-mesh returned HTTP 404

## Screenshots
- Not applicable; documentation-only change