### PR TITLE
docs: close Batch 2 NeuralLiquid migration prep

### DIFF
--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -146,22 +146,24 @@ Delivered:
 
 Current production behavior:
 
-- Sluice reports `configuration_missing` until `SLUICE_BASE_URL` is set.
-- Azure metadata confirms the Sluice LiteLLM gateway custom domain is `https://litellm.sluice.phoenixvc.tech`; CogMesh prod Terraform now has non-secret hooks for `SLUICE_BASE_URL` and a Key Vault reference for `SLUICE_API_KEY`, but leaves them unset until auth is confirmed.
-- Docket reports `in-memory` until `DOCKET_BASE_URL` is set.
-- Docket canonical API URL is now live at `https://docket.phoenixvc.tech`.
-- Do not set `DOCKET_BASE_URL` until CogMesh-to-Docket auth and the production ingestion contract are implemented. The canonical Docket API has auth enabled and exposes bearer-secured cost/action endpoints, but it does not currently expose a CogMesh-compatible model-usage ingestion endpoint.
+- Sluice reports `configured` in production and staging when checked through CogMesh.
+- Azure metadata confirms the Sluice LiteLLM gateway custom domain is `https://litellm.sluice.phoenixvc.tech`; CogMesh production and staging App Service settings now use `SLUICE_BASE_URL` plus a resolved Key Vault reference for `SLUICE_API_KEY`.
+- Docket reports `external-auth-configured` through CogMesh.
+- Docket canonical API URL is live at `https://docket.phoenixvc.tech`.
+- CogMesh-to-Docket usage ingestion is configured through `DOCKET_BASE_URL=https://docket.phoenixvc.tech` and `DOCKET_API_KEY`; the production smoke returned HTTP 202 through CogMesh and Docket logs showed HTTP 200 at `/usage/model-events`.
 - The Sluice health endpoint does not perform a live model call; it reports configuration/routing readiness and `liveProbeAttempted=false`.
 
 ## Closeout Refresh - 2026-07-14
 
-- Batch 2 source work is merged through `dev` commit `eac1d23`:
+- Batch 2 source work is merged through `dev` commit `792454d`:
   - PR #512 migration package.
   - PR #513 routing Terraform settings.
   - PR #517 CogMesh Docket outbound usage forwarding.
   - PR #519 Docket usage auth settings.
   - PR #520 Docket API key deploy bridge.
   - PR #521/#523 agent-ops/schema cleanup and untracked artifact cleanup.
+  - PR #524 Sluice gateway secret bridge durability.
+  - PR #525 NeuralLiquid OIDC readiness record.
 - Docket PR `phoenixvc/docket#99` is merged and Docket production deploy run `29308313859` completed successfully.
 - CogMesh API deploy run `29274844076` completed successfully for the Docket API key bridge.
 - GitHub repo variables now include:
@@ -183,7 +185,7 @@ Current production behavior:
   - `directProviderFallbackAllowed=false`
   - `docketConfigured=true`
   - `docketMode=external-auth-configured`
-- `https://cognitive-mesh-api-prod-staging.azurewebsites.net/api/v1/sluice/health` previously reported the same configured state before the Key Vault rotation; after rotation, its Key Vault reference is resolved, but the final HTTP health retry should be repeated if the slot is needed for transfer validation.
+- `https://cognitive-mesh-api-prod-staging.azurewebsites.net/api/v1/sluice/health` was rechecked after the Key Vault rotation and reports the same configured state.
 - Authenticated Sluice gateway check succeeded:
   - `GET https://litellm.sluice.phoenixvc.tech/v1/models` returned HTTP 200 with the configured model routes when called with the gateway key.
 - Docket health check succeeded:
@@ -201,6 +203,22 @@ Current production behavior:
 - `neuralliquid/cognitive-mesh` does not currently exist, so target-repo variables, secrets, environments, app installations, and DNS/custom-domain ownership must be validated after the actual GitHub repository transfer.
 - Durability note: Terraform full apply still needs review because existing App Service drift can affect frontend settings and image tags, but Sluice secret wiring now uses the preferred Key Vault reference path.
 
+Batch 2 closeout status:
+
+- Complete for migration prep, routing, auth wiring, and production smoke evidence.
+- Not a repository transfer. The target repo still returns GitHub HTTP 404 until Batch 3 performs the transfer.
+- Remaining before any full prod Terraform apply: reconcile frontend App Service drift.
+
+Batch 3 pre-transfer discovery:
+
+- Baton task: `3b3a125b-6db5-4d80-8fb2-422d20f9c9f0`.
+- Source repo metadata: public, default branch `dev`, issues/projects/wiki enabled, merge/squash/rebase enabled, delete-branch-on-merge disabled.
+- Source repo has one disabled repository ruleset, `Main Branch Protection` (`13093301`), targeting the default branch.
+- Source repo environments returned by GitHub: `copilot` and `production`; production has no protection rules.
+- Source repo webhooks list is empty; GitHub Pages endpoint returns 404.
+- Visible source collaborators: `mareeben` admin and `JustAGhosT` admin.
+- Target org `neuralliquid` is visible; target repo `neuralliquid/cognitive-mesh` still returns HTTP 404.
+
 ## Transfer Baseline Refresh - 2026-07-13
 
 - PR #512 and PR #513 are merged into `dev`.
@@ -211,22 +229,24 @@ Current production behavior:
 - `pnpm run lint` exited 0 with 53 existing warnings.
 - `pnpm run test -- --runInBand` succeeded with 18 suites and 137 tests passed; existing React `act(...)` console warning observed.
 - `pnpm run build` succeeded; existing Style Dictionary and Next config/deprecation warnings remain.
-- `gh auth status` now includes `admin:org`, `read:packages`, `repo`, and `user`, but all four selected GitHub App repository-coverage API calls still return HTTP 403 because GitHub requires a PAT, GitHub App-authorized token, or basic auth for that endpoint.
+- At the time of this baseline, `gh auth status` included `admin:org`, `read:packages`, `repo`, and `user`, but the default GitHub OAuth token could not expand selected GitHub App repository coverage. This was later superseded by PAT-backed installation repository queries that cleared the active app-coverage gate.
 - Classic PAT verification cleared the active GitHub App coverage gate:
   - Renovate (`101140936`) includes `phoenixvc/cognitive-mesh`.
   - Stilla (`116485390`) includes `phoenixvc/cognitive-mesh`.
   - Devin (`68460896`) does not include `phoenixvc/cognitive-mesh`, accepted because Devin is inactive for this transfer.
   - phoenixvc-actions-runner (`111911804`) has zero repositories, accepted because the runner app is not currently deployed.
 
-## Org Migration Tasks After Sluice Routing
+## Batch 3 Org Migration Tasks
 
-1. Decide final target org/repo names and update GitHub Actions OIDC federated credentials.
-2. Recreate or transfer repo variables/secrets without exposing values.
-3. Decide DNS ownership timing:
+1. Confirm final source state and obtain explicit approval for the irreversible GitHub repository transfer.
+2. Transfer `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
+3. Recreate or validate target repo variables/secrets without exposing values.
+4. Validate target repo environments, branch protections/rulesets, selected app installations, and Actions OIDC.
+5. Decide DNS ownership timing:
    - Keep `mystira-workspace` DNS as a temporary bridge if it currently owns the zones.
    - Move NeuralLiquid-owned DNS/deployment state into NeuralLiquid-owned infra before long-term production.
-4. Bind custom domains and certificates for the chosen `*.cognitivemesh.neuralliquid.ai` hosts.
-5. Run final frontend/API deploys from the target org after OIDC and secrets are confirmed.
+6. Bind or validate custom domains and certificates for the chosen `*.cognitivemesh.neuralliquid.ai` hosts.
+7. Run final frontend/API deploys from the target org after OIDC and secrets are confirmed.
 
 ## Handoff - 2026-07-13 Sluice/Docket Migration Prep
 
@@ -248,8 +268,8 @@ work_completed:
       - staging.cognitivemesh.neuralliquid.ai CORS origin
   - Verified the intended prod Sluice base URL but left it gated on a managed API key reference:
       - https://litellm.sluice.phoenixvc.tech
-  - Left DOCKET_BASE_URL empty because the canonical Docket endpoint is live but not approved for CogMesh until auth and usage-ingestion semantics are confirmed.
-  - Updated manifest and this handoff with the Docket blocker.
+  - Left the Docket base URL unset at the time because the canonical Docket endpoint was not yet approved for CogMesh until auth and usage-ingestion semantics were confirmed. Superseded on 2026-07-14: Docket usage ingestion is now configured and production-smoked.
+  - Updated manifest and this handoff with the then-current Docket blocker.
   - Configured canonical Docket API hostname:
       - docket.phoenixvc.tech CNAME -> pvc-shared-costops-api.ashymushroom-1f7d8121.southafricanorth.azurecontainerapps.io
       - asuid.docket.phoenixvc.tech TXT -> Container App custom-domain verification ID
@@ -288,7 +308,7 @@ verification:
 blockers:
   - CogMesh-to-Docket service auth is identifiable but not wired; Docket supports Azure AD bearer tokens and optional X-API-Key, but CogMesh does not currently send either to Docket.
   - CogMesh-to-Docket production ingestion contract is not compatible yet; canonical Docket does not expose a model-usage ingestion endpoint matching CogMesh's local DocketUsageEvent.
-  - CogMesh-to-Sluice auth scheme still needs production confirmation.
+  - CogMesh-to-Sluice auth scheme still needed production confirmation at the time. Superseded on 2026-07-14: Sluice auth is configured through a resolved Key Vault reference and gateway auth was verified.
   - Full prod Terragrunt plan is not apply-safe yet because frontend App Service drift would remove existing frontend settings and move images back to Terraform-managed values.
 risks:
   - Applying the full prod plan without drift reconciliation could remove frontend app settings managed outside Terraform.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
@@ -324,12 +324,10 @@ references:
   archived_prototypes: []
 
 blockers:
-  - Batch 2 transfer remains partial until migration package PR #512 and companion Terraform routing PR #513 are reviewed and merged.
-  - Deployment workflows still need the local workflow/Terraform changes to be committed and pushed before GitHub Actions will use the new Web App deployment path.
-  - Old cognitivemesh.io DNS names do not resolve; replace with staging.cognitivemesh.neuralliquid.ai and cognitivemesh.neuralliquid.ai.
-  - After repository transfer, add equivalent federated credential subjects for neuralliquid/cognitive-mesh to nl-cognitive-mesh-github-actions or a NeuralLiquid-owned replacement app registration.
-  - GitHub Apps with selected repository access still need per-app repository selection confirmation before transfer; selected installations are visible, but expanding selected app repository lists through the API returned 403 and requires the broader GitHub OAuth `user` scope.
-  - Docket must be live under canonical `docket` service identity before CogMesh sets `DOCKET_BASE_URL`; do not use the old `pvc-shared-costops-api` endpoint as the long-term dependency.
+  - Batch 3 repository transfer has not been performed; neuralliquid/cognitive-mesh still returns GitHub HTTP 404 until transfer.
+  - Target-repository variables, secrets, environments, branch protections/rulesets, app installations, and Actions OIDC cannot be validated until after transfer.
+  - Frontend App Service Terraform drift must be reconciled or explicitly accepted before any full production Terraform apply.
+  - DNS/custom-domain ownership must be revalidated after transfer; keep Mystira workspace DNS as a temporary bridge only if it remains the current source of truth.
 
 resolved_blockers:
   - User confirmed the stale phoenix-flow ecosystem entry should be baton; manifest now classifies baton as the PhoenixVC-hosted project tracker dependency.
@@ -352,8 +350,13 @@ resolved_blockers:
   - The only visible OpenAI resource match is pvc-prod-sluice-aoai in pvc-prod-sluice-rg, supporting the README claim that model access should route through sluice rather than a Cognitive Mesh-owned AOAI resource.
   - GitHub App installation inventory is visible for phoenixvc. Relevant installed apps include Renovate, Stilla, Codecov, Cursor, ChatGPT Codex Connector, Claude, Vercel, Sentry, CodeRabbit, Greptile, Devin, and phoenixvc-actions-runner.
   - Selected app installation IDs were narrowed on 2026-07-13: Renovate `101140936`, Stilla `116485390`, Devin `68460896`, and phoenixvc-actions-runner `111911804`.
+  - Selected GitHub App repository coverage was cleared by PAT-backed installation repository queries: Renovate and Stilla include phoenixvc/cognitive-mesh, Devin is inactive for this transfer, and phoenixvc-actions-runner has zero repositories and is not deployed.
   - GitHub package inventory is visible; no phoenixvc Cognitive Mesh container packages were found.
   - Organization Actions secrets and variables are visible; org variables are empty and org secrets do not contain the ACR/AKS/Slack names required by Cognitive Mesh deployment workflows.
+  - Batch 2 migration package, routing Terraform, Docket usage forwarding, Docket auth settings, Sluice secret bridge durability, and OIDC readiness documentation are merged through dev commit 792454d.
+  - Production and staging CogMesh Sluice health report configured, direct provider fallback disabled, and Docket external auth configured.
+  - Production and staging App Service Key Vault references for SLUICE_API_KEY report Resolved.
+  - Docket health returns 200 with table backend, and CogMesh-to-Docket usage ingestion has been production-smoked through the canonical Docket endpoint.
 
 validation:
   local_searches:
@@ -375,7 +378,7 @@ validation:
     - orgs/phoenixvc/actions/variables
     - orgs/phoenixvc/installations
     - orgs/phoenixvc/packages?package_type=container
-    - /user/installations/{installation_id}/repositories for selected apps (still blocked on 2026-07-13; GitHub returned 403 and requested OAuth user scope)
+    - /user/installations/{installation_id}/repositories for selected apps (403 with the default gh OAuth token; later cleared with PAT-backed installation repository queries)
   azure_queries:
     - az account show
     - az resource list for Cognitive Mesh and mesh names

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
@@ -207,7 +207,7 @@ These names must be validated as repository, organization, or environment secret
   - `renovate`: `101140936`
   - `phoenixvc-actions-runner`: `111911804`
   - `stilla`: `116485390`
-- Attempting to expand selected app repository lists through `/user/installations/{installation_id}/repositories` still returned 403 on 2026-07-13 and requires the broader GitHub OAuth `user` scope, not only `read:user`.
+- Attempting to expand selected app repository lists through `/user/installations/{installation_id}/repositories` returned 403 on 2026-07-13 with the default GitHub OAuth token. This was later superseded by PAT-backed installation repository queries that cleared the active app-coverage gate.
 
 ## Pages
 
@@ -430,17 +430,19 @@ This rollback is incomplete until the blockers below are resolved.
 
 ## Blockers Before Transfer
 
-- Batch 2 artifacts and routing Terraform changes are isolated into clean PR branches and must be reviewed/merged before transfer: migration package PR #512 and Terraform routing PR #513.
-- Deployment workflows still need any approved local workflow/Terraform changes to be committed and pushed before GitHub Actions will use the new Web App deployment path.
-- Old `cognitivemesh.io`, `staging.cognitivemesh.io`, and `api.cognitivemesh.io` do not resolve; replace with `*.cognitivemesh.neuralliquid.ai`.
-- After repository transfer, add equivalent federated credential subjects for `neuralliquid/cognitive-mesh` to `nl-cognitive-mesh-github-actions` or a NeuralLiquid-owned replacement app registration.
-- Selected-repository GitHub App coverage still needs confirmation for `cognitive-mesh`, especially Renovate, Stilla, Devin, and phoenixvc-actions-runner; API expansion returned 403 and requires OAuth `user` scope or manual org UI review.
+- Batch 3 repository transfer has not been performed; `neuralliquid/cognitive-mesh` currently returns GitHub HTTP 404.
+- Target repository variables, secrets, environments, branch protections/rulesets, selected app installations, and Actions OIDC must be recreated or validated after transfer.
+- Frontend App Service Terraform drift must be reconciled or explicitly accepted before any full production Terraform apply.
+- DNS/custom-domain ownership must be revalidated after transfer; use `*.cognitivemesh.neuralliquid.ai` hosts and keep any Mystira workspace DNS bridge only while it remains the current source of truth.
 
 ## Resolved Or Narrowed Blockers
 
 - `phoenix-flow` is resolved by user confirmation: use `baton` as the project tracker reference.
 - Active Azure account, tenant, and subscription were identified.
 - Shared ACR decision is resolved: use `myssharedacr` for the initial NeuralLiquid deployment.
+- Batch 2 migration package, routing Terraform, Docket usage forwarding, Docket auth settings, Sluice secret bridge durability, and OIDC readiness documentation are merged through `dev` commit `792454d`.
+- Selected GitHub App repository coverage was cleared by PAT-backed installation repository queries.
+- CogMesh-to-Sluice and CogMesh-to-Docket production routing/auth are configured and production-smoked.
 - Initial deployment shape is resolved: production only, with `staging` treated as a production slot and `prod` as production.
 - Domain direction is resolved for now: use `x.cognitivemesh.neuralliquid.ai`.
 - AKS is resolved out of scope for the initial deployment; `AKS_CLUSTER_NAME` and `AKS_RESOURCE_GROUP` are not required.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
@@ -86,8 +86,7 @@ Action: preserve history; add current-location notes only where needed.
 
 ## Unknown Or Blocked References
 
-- Selected-repository GitHub App access for Renovate, Stilla, Devin and phoenixvc-actions-runner still needs manual/API confirmation. Installation IDs are known, but `/user/installations/{installation_id}/repositories` returned 403 and requires OAuth `user` scope.
-- Docket canonical production endpoint and CogMesh-to-Docket auth scheme are not confirmed.
-- CogMesh-to-Sluice production auth scheme is not confirmed.
-- Batch 2 edits are now split into clean PR branches: migration package PR #512 and Terraform routing PR #513.
-- Direct model-provider secrets should remain quarantined until all model egress is verified through Sluice.
+- Batch 3 target repository settings cannot be validated until `phoenixvc/cognitive-mesh` is transferred and `neuralliquid/cognitive-mesh` exists.
+- Target repository variables, secrets, environments, branch protections/rulesets, selected app installations, and Actions OIDC must be recreated or validated after transfer.
+- Frontend App Service Terraform drift must be reconciled or explicitly accepted before any full production Terraform apply.
+- Direct model-provider secrets should remain quarantined; production model egress is routed through Sluice, with direct provider fallback disabled.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
@@ -4,19 +4,19 @@ Generated: 2026-07-13
 
 Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
 
-No repository transfer has been performed in this batch.
+No repository transfer has been performed yet.
 
 ## Current Rollback State
 
 - Repository still exists at `phoenixvc/cognitive-mesh`.
-- Latest fetched `origin/dev` checked on 2026-07-13 is `5b76bf34389b0a82dcc546c2eb09d0494cb09e1e`.
-- Batch 2 work has been split into clean PR branches from `origin/dev`: migration package PR #512 and Terraform routing PR #513.
+- Latest fetched `origin/dev` checked on 2026-07-14 is `792454d`.
+- Batch 2 work is merged into `dev`; it includes the migration package, routing Terraform, Docket forwarding/auth settings, Sluice secret bridge durability, and OIDC readiness documentation.
 - Production App Services remain in `nl-prod-cognitive-mesh-rg`.
-- Deployment identity `nl-cognitive-mesh-github-actions` currently has PhoenixVC repository federated subjects.
+- Deployment identity `nl-cognitive-mesh-github-actions` currently has PhoenixVC and NeuralLiquid repository federated subjects.
 - Shared ACR remains `myssharedacr.azurecr.io`.
 - CogMesh production infrastructure keeps `enable_openai = false`.
 - Sluice is an external PhoenixVC-hosted dependency.
-- Docket is blocked until the canonical renamed service is live.
+- Docket canonical endpoint is live at `https://docket.phoenixvc.tech`.
 
 ## If Pre-Transfer Changes Need Reversal
 

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -6,9 +6,9 @@ Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
 
 ## Current Status
 
-Status: Batch 2 closeout / repository transfer still not performed.
+Status: Batch 2 closeout complete for migration prep and Sluice/Docket routing; Batch 3 repository transfer not yet performed.
 
-Reason: Batch 2 migration artifacts and routing prep are merged into `dev`, and production now has Docket plus Sluice routing settings applied. Repository transfer remains undone and should be routed through the Baton Migration Coordinator for org/OIDC/secrets/DNS work, the Baton Evidence and Claims Auditor for Docket ingestion evidence, and the Baton FinOps and Runway Analyst for cost-attribution readiness. Preserve the transfer block until those prerequisites are verified.
+Reason: Batch 2 migration artifacts, routing prep, deploy-workflow durability, Docket usage forwarding, Docket auth settings, and Sluice Key Vault reference wiring are merged into `dev`. Production and staging now report Sluice configured, direct provider fallback disabled, and Docket external auth configured. Repository transfer remains undone and is now the Batch 3 track through the Baton Migration Coordinator for org/OIDC/secrets/DNS work. Preserve the transfer block until the operator explicitly approves the irreversible GitHub transfer step.
 
 ## Evidence Reviewed
 
@@ -95,19 +95,20 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Sluice authenticated route from CogMesh after auth is configured.
 - Docket authenticated usage-ingestion route from CogMesh after Docket PR #99 and the CogMesh outbound client PR are merged and deployed with production settings.
 
-## Blockers
+## Historical Blockers
 
-- CogMesh-to-Docket code-level contract is implemented but not production-smoked. Merge and deploy Docket PR #99, merge and deploy the CogMesh outbound client PR, then set `DOCKET_BASE_URL` plus either `DOCKET_AUDIENCE`/`DOCKET_SCOPE` for Entra app-role auth or `DOCKET_API_KEY` for the short bridge.
-- CogMesh-to-Sluice auth scheme still needs production confirmation.
-- Repository transfer must not proceed until blockers are resolved, even though the clean source build/test baseline is now recorded.
+- CogMesh-to-Docket code-level contract was implemented and production-smoked on 2026-07-14.
+- CogMesh-to-Sluice production auth was confirmed with the gateway key and is now wired through a Key Vault reference.
+- Selected GitHub App repository coverage was cleared by PAT-backed installation repository queries.
+- The remaining transfer gate is operational, not Batch 2 implementation: do not perform the irreversible GitHub repository transfer until explicitly approved for Batch 3 execution.
 
 ## Next Verification Action
 
-1. Merge and deploy Docket PR #99.
-2. Merge and deploy the CogMesh outbound Docket usage client PR.
-3. Configure CogMesh `DOCKET_BASE_URL` and service auth after Docket is deployed.
-4. Confirm CogMesh-to-Sluice production auth.
-5. Run full Terraform validation and prod plan after frontend App Service drift is reconciled.
+1. Reconcile or explicitly accept frontend App Service Terraform drift before any full prod apply.
+2. Confirm final source repository state immediately before transfer.
+3. Perform the GitHub repository transfer to `neuralliquid/cognitive-mesh` only after explicit operator approval.
+4. Recreate/validate target repository variables, secrets, environments, app installations, branch protections/rulesets, and Actions OIDC.
+5. Run final deploys from the target org after target repository settings are validated.
 
 ## Refresh - 2026-07-14
 
@@ -145,11 +146,35 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Verified `neuralliquid/cognitive-mesh` currently returns GitHub HTTP 404, so target-repository settings cannot be validated until the repository is transferred.
 - Captured current source repository variable and secret names for transfer validation; no secret values were recorded.
 
+## Batch 2 Closeout Refresh - 2026-07-14
+
+- Confirmed local `dev` matches `origin/dev` at `792454d`, after PR #524 and PR #525.
+- Confirmed only open source-repo PR is Renovate PR #494 (`renovate/pin-dependencies`), unrelated to migration transfer.
+- Confirmed source repo variables: `AZURE_WEBAPP_RESOURCE_GROUP`, `COGMESH_DOCKET_BASE_URL`, `COGMESH_SLUICE_API_KEY_SECRET_URI`, `COGMESH_SLUICE_BASE_URL`, `COGMESH_SLUICE_MAX_TOKENS`, `COGMESH_SLUICE_MODEL`, `COGNITIVE_MESH_API_APP_NAME`, `COGNITIVE_MESH_FRONTEND_APP_NAME`, `NEXT_PUBLIC_MYSTIRA_AUTH_CLIENT_ID`, and `NEXT_PUBLIC_MYSTIRA_TENANT_ID`.
+- Confirmed source repo secrets by name only: `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `COGMESH_DOCKET_API_KEY`, `SONAR_HOST_URL`, and `SONAR_TOKEN`.
+- Confirmed source repo environments returned by GitHub: `copilot` and `production`.
+- Confirmed production and staging `/api/v1/sluice/health` return `status=configured`, `sluiceConfigured=true`, `directProviderFallbackAllowed=false`, `docketConfigured=true`, and `docketMode=external-auth-configured`.
+- Confirmed production and staging App Service Key Vault references for `SLUICE_API_KEY` report `Resolved` through ARM config-reference reads.
+- Confirmed `https://docket.phoenixvc.tech/health` returns `{"status":"ok","backend":"table"}`.
+- Confirmed `neuralliquid/cognitive-mesh` still returns GitHub HTTP 404. Target-repo settings remain unvalidated because the repository has not been transferred.
+
+## Batch 3 Pre-Transfer Discovery - 2026-07-14
+
+- Baton Batch 3 task opened: `3b3a125b-6db5-4d80-8fb2-422d20f9c9f0`.
+- Source repository metadata: public repository, default branch `dev`, issues/projects/wiki enabled, squash/merge/rebase all allowed, delete-branch-on-merge disabled.
+- Source branches returned by GitHub include `dev`, `main`, `gh-pages`, active agent/renovate/dependabot branches, and historical feature branches; none are reported protected.
+- Source repository rulesets: one repository branch ruleset, `Main Branch Protection` (`13093301`), target default branch, enforcement `disabled`.
+- Source production environment exists and has no protection rules or deployment branch policy.
+- Source repository webhooks list is empty.
+- Source repository topics: `agent-orchestration`, `azure-openai`, `compliance`, `governance`, `observability`, `rbac`, `agent`, `ai`, `csharp`, `dotnet`, `reasoning`, `typescript`, `active`, `phoenixvc`, `neuralliquid`.
+- Source repository collaborators visible through GitHub: `mareeben` admin and `JustAGhosT` admin.
+- GitHub Pages endpoint returns 404, so no active Pages site was visible through the repository Pages API.
+- Target organization `neuralliquid` is visible; target repository `neuralliquid/cognitive-mesh` still returns GitHub HTTP 404.
+
 ## Remaining Before Transfer
 
-1. Publish and merge the deploy-workflow durability patch that keeps the Sluice Key Vault URI path and optional direct-secret fallback.
-2. Baton Migration Coordinator: reconcile frontend App Service Terraform drift before any full prod apply.
-3. Baton Migration Coordinator: perform the actual GitHub repository transfer to `neuralliquid/cognitive-mesh` once approved.
-4. Baton Migration Coordinator: recreate/validate repository variables, secrets, environments, app installations, and DNS/custom-domain ownership after transfer.
-5. Baton FinOps and Runway Analyst: verify Docket-backed cost-attribution readiness from the Sluice-routed CogMesh usage path before using the transfer as funding evidence.
-6. Baton Evidence and Claims Auditor: validate that public migration/funding claims distinguish implemented Sluice/Docket routing from remaining transfer prerequisites.
+1. Baton Migration Coordinator: reconcile frontend App Service Terraform drift before any full prod apply.
+2. Baton Migration Coordinator: perform the actual GitHub repository transfer to `neuralliquid/cognitive-mesh` once explicitly approved.
+3. Baton Migration Coordinator: recreate/validate repository variables, secrets, environments, app installations, branch protections/rulesets, and DNS/custom-domain ownership after transfer.
+4. Baton FinOps and Runway Analyst: verify Docket-backed cost-attribution readiness from the Sluice-routed CogMesh usage path before using the transfer as funding evidence.
+5. Baton Evidence and Claims Auditor: validate that public migration/funding claims distinguish implemented Sluice/Docket routing from remaining transfer prerequisites.


### PR DESCRIPTION
## Summary
- close Batch 2 as complete for migration prep, Sluice/Docket routing, auth wiring, and production smoke evidence
- update manifest, handoff, verification, rollback, reference inventory, and pre-transfer snapshot to remove stale blockers
- open Batch 3 as the repository transfer and target-org validation track with Baton task 3b3a125b-6db5-4d80-8fb2-422d20f9c9f0

## Verification
- dotnet build CognitiveMesh.sln
- dotnet test CognitiveMesh.sln --no-build
- git diff --check

## Transfer note
No repository transfer, Terraform apply, secret value read, or deployment was performed. Batch 3 still requires explicit approval before the irreversible GitHub transfer to neuralliquid/cognitive-mesh.