### PR TITLE
docs: record Batch 3 NeuralLiquid transfer

### DIFF
--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/handoff.md
@@ -4,8 +4,10 @@ Last updated: 2026-07-14
 
 ## Current State
 
-- Repository: `phoenixvc/cognitive-mesh`
+- Repository: `neuralliquid/cognitive-mesh`
 - Branch: `dev`
+- Transfer completed: 2026-07-14
+- Previous repository path: `phoenixvc/cognitive-mesh` redirects to `neuralliquid/cognitive-mesh`
 - Latest deployed/frontend merge commit verified this session: `5b76bf34389b0a82dcc546c2eb09d0494cb09e1e`
 - Latest deployed API/frontend integration commit from Sluice/Docket work: `6e1e8fc991f73bee2e6a8fe017fa8b917cfaad87`
 - Prod Azure resource group: `nl-prod-cognitive-mesh-rg`
@@ -200,24 +202,38 @@ Current production behavior:
 - Source repo transfer settings snapshot:
   - Variables present on `phoenixvc/cognitive-mesh`: `AZURE_WEBAPP_RESOURCE_GROUP`, `COGMESH_DOCKET_BASE_URL`, `COGMESH_SLUICE_API_KEY_SECRET_URI`, `COGMESH_SLUICE_BASE_URL`, `COGMESH_SLUICE_MAX_TOKENS`, `COGMESH_SLUICE_MODEL`, `COGNITIVE_MESH_API_APP_NAME`, `COGNITIVE_MESH_FRONTEND_APP_NAME`, `NEXT_PUBLIC_MYSTIRA_AUTH_CLIENT_ID`, `NEXT_PUBLIC_MYSTIRA_TENANT_ID`.
   - Secrets present on `phoenixvc/cognitive-mesh`: `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `COGMESH_DOCKET_API_KEY`, `SONAR_HOST_URL`, `SONAR_TOKEN`.
-- `neuralliquid/cognitive-mesh` does not currently exist, so target-repo variables, secrets, environments, app installations, and DNS/custom-domain ownership must be validated after the actual GitHub repository transfer.
+- `neuralliquid/cognitive-mesh` now exists and is the canonical repository path. The previous `phoenixvc/cognitive-mesh` API path redirects to the transferred repository.
 - Durability note: Terraform full apply still needs review because existing App Service drift can affect frontend settings and image tags, but Sluice secret wiring now uses the preferred Key Vault reference path.
 
 Batch 2 closeout status:
 
 - Complete for migration prep, routing, auth wiring, and production smoke evidence.
-- Not a repository transfer. The target repo still returns GitHub HTTP 404 until Batch 3 performs the transfer.
+- Batch 2 itself was not a repository transfer. Batch 3 performed the transfer on 2026-07-14.
 - Remaining before any full prod Terraform apply: reconcile frontend App Service drift.
 
-Batch 3 pre-transfer discovery:
+Batch 3 transfer and target-org validation:
 
 - Baton task: `3b3a125b-6db5-4d80-8fb2-422d20f9c9f0`.
-- Source repo metadata: public, default branch `dev`, issues/projects/wiki enabled, merge/squash/rebase enabled, delete-branch-on-merge disabled.
-- Source repo has one disabled repository ruleset, `Main Branch Protection` (`13093301`), targeting the default branch.
-- Source repo environments returned by GitHub: `copilot` and `production`; production has no protection rules.
-- Source repo webhooks list is empty; GitHub Pages endpoint returns 404.
-- Visible source collaborators: `mareeben` admin and `JustAGhosT` admin.
-- Target org `neuralliquid` is visible; target repo `neuralliquid/cognitive-mesh` still returns HTTP 404.
+- Transfer API call completed successfully; both `phoenixvc/cognitive-mesh` and `neuralliquid/cognitive-mesh` now resolve to `neuralliquid/cognitive-mesh`.
+- Local `origin` was updated to `https://github.com/neuralliquid/cognitive-mesh.git`.
+- Target repo remains public, default branch `dev`, issues/projects/wiki enabled, merge/squash/rebase enabled, delete-branch-on-merge disabled.
+- Target repo variables and secrets are present by name; no secret values were read.
+- Target repo environments returned by GitHub: `copilot` and `production`; production has no protection rules.
+- Target repo has one disabled repository ruleset, `Main Branch Protection` (`13093301`), targeting the default branch.
+- Target repo webhooks list is empty; GitHub Pages endpoint returns 404.
+- Visible target collaborators: `JustAGhosT` admin and `mareeben` write. Before transfer, `mareeben` appeared as admin; this permission change should be reviewed if admin access is still required.
+- Actions are enabled and workflows are active.
+- OIDC app registration `nl-cognitive-mesh-github-actions` has NeuralLiquid federated subjects for `dev`, `main`, and `production`.
+- Target-org deploy runs completed successfully:
+  - API deploy run `29350528046`, image `myssharedacr.azurecr.io/cognitive-mesh-api:sha-5e0567a`.
+  - Frontend deploy run `29350528139`, image `myssharedacr.azurecr.io/cognitive-mesh-frontend:sha-5e0567a`.
+- Post-transfer health checks succeeded:
+  - `https://cognitive-mesh-api-prod.azurewebsites.net/healthz`
+  - `https://cognitive-mesh-api-prod-staging.azurewebsites.net/healthz`
+  - `https://cognitive-mesh-frontend-prod.azurewebsites.net/api/health`
+  - `https://cognitive-mesh-frontend-prod-staging.azurewebsites.net/api/health`
+  - `https://api.cognitivemesh.neuralliquid.ai/api/v1/sluice/health`
+  - `https://docket.phoenixvc.tech/health`
 
 ## Transfer Baseline Refresh - 2026-07-13
 
@@ -238,15 +254,13 @@ Batch 3 pre-transfer discovery:
 
 ## Batch 3 Org Migration Tasks
 
-1. Confirm final source state and obtain explicit approval for the irreversible GitHub repository transfer.
-2. Transfer `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
-3. Recreate or validate target repo variables/secrets without exposing values.
-4. Validate target repo environments, branch protections/rulesets, selected app installations, and Actions OIDC.
-5. Decide DNS ownership timing:
+1. Review whether `mareeben` should be restored from write to admin on the transferred repository.
+2. Reconcile frontend App Service Terraform drift before any full prod Terraform apply.
+3. Decide DNS ownership timing:
    - Keep `mystira-workspace` DNS as a temporary bridge if it currently owns the zones.
    - Move NeuralLiquid-owned DNS/deployment state into NeuralLiquid-owned infra before long-term production.
-6. Bind or validate custom domains and certificates for the chosen `*.cognitivemesh.neuralliquid.ai` hosts.
-7. Run final frontend/API deploys from the target org after OIDC and secrets are confirmed.
+4. Move NeuralLiquid-owned DNS/deployment state into NeuralLiquid-owned infra before long-term production.
+5. Verify Docket-backed cost-attribution evidence before using the migration as funding evidence.
 
 ## Handoff - 2026-07-13 Sluice/Docket Migration Prep
 
@@ -314,7 +328,7 @@ risks:
   - Applying the full prod plan without drift reconciliation could remove frontend app settings managed outside Terraform.
   - The canonical Docket hostname currently fronts the existing pvc-shared-costops-api Container App; Docket repo naming and Terraform resource names still need follow-up cleanup.
 rollback_state:
-  - No repository transfer performed.
+  - No repository transfer had been performed in that earlier Batch 1/2 prep step. Superseded on 2026-07-14: Batch 3 transferred the repository to `neuralliquid/cognitive-mesh`.
   - No Terraform apply performed.
   - Docket hostname rollback is to repoint docket.phoenixvc.tech CNAME away from the Container App and remove the Container App hostname binding.
   - Cognitive Mesh changes remain local documentation and Terraform configuration only.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/manifest.yaml
@@ -1,5 +1,7 @@
 source_repository: phoenixvc/cognitive-mesh
 target_repository: neuralliquid/cognitive-mesh
+current_repository: neuralliquid/cognitive-mesh
+transferred_at: 2026-07-14
 generated_at: 2026-07-12
 generated_from:
   local_checkout: C:/tmp/cognitive-mesh
@@ -324,10 +326,9 @@ references:
   archived_prototypes: []
 
 blockers:
-  - Batch 3 repository transfer has not been performed; neuralliquid/cognitive-mesh still returns GitHub HTTP 404 until transfer.
-  - Target-repository variables, secrets, environments, branch protections/rulesets, app installations, and Actions OIDC cannot be validated until after transfer.
+  - Review whether `mareeben` should be restored from write to admin on the transferred repository.
   - Frontend App Service Terraform drift must be reconciled or explicitly accepted before any full production Terraform apply.
-  - DNS/custom-domain ownership must be revalidated after transfer; keep Mystira workspace DNS as a temporary bridge only if it remains the current source of truth.
+  - DNS/custom-domain ownership must be moved into NeuralLiquid-owned infrastructure before long-term production; keep Mystira workspace DNS as a temporary bridge only if it remains the current source of truth.
 
 resolved_blockers:
   - User confirmed the stale phoenix-flow ecosystem entry should be baton; manifest now classifies baton as the PhoenixVC-hosted project tracker dependency.
@@ -357,6 +358,9 @@ resolved_blockers:
   - Production and staging CogMesh Sluice health report configured, direct provider fallback disabled, and Docket external auth configured.
   - Production and staging App Service Key Vault references for SLUICE_API_KEY report Resolved.
   - Docket health returns 200 with table backend, and CogMesh-to-Docket usage ingestion has been production-smoked through the canonical Docket endpoint.
+  - Repository transfer completed on 2026-07-14; old phoenixvc/cognitive-mesh API path redirects to neuralliquid/cognitive-mesh.
+  - Target repository variables, secrets, environments, ruleset, Actions enablement, active workflows, OIDC federated credentials, and no-webhook/no-Pages state were validated after transfer without reading secret values.
+  - API and frontend deploys ran successfully from neuralliquid/cognitive-mesh on dev and deployed sha-5e0567a images to production and staging.
 
 validation:
   local_searches:

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/pre-transfer-snapshot.md
@@ -430,8 +430,8 @@ This rollback is incomplete until the blockers below are resolved.
 
 ## Blockers Before Transfer
 
-- Batch 3 repository transfer has not been performed; `neuralliquid/cognitive-mesh` currently returns GitHub HTTP 404.
-- Target repository variables, secrets, environments, branch protections/rulesets, selected app installations, and Actions OIDC must be recreated or validated after transfer.
+- Batch 3 repository transfer was performed on 2026-07-14; `neuralliquid/cognitive-mesh` now exists.
+- Target repository variables, secrets, environments, branch protections/rulesets, selected app installations, and Actions OIDC were validated after transfer without reading secret values.
 - Frontend App Service Terraform drift must be reconciled or explicitly accepted before any full production Terraform apply.
 - DNS/custom-domain ownership must be revalidated after transfer; use `*.cognitivemesh.neuralliquid.ai` hosts and keep any Mystira workspace DNS bridge only while it remains the current source of truth.
 
@@ -476,4 +476,4 @@ This rollback is incomplete until the blockers below are resolved.
 - Queried Azure account, resources, ACR, AKS, AOAI, and candidate app registration federated credentials.
 - Checked DNS resolution for the workflow public URLs.
 - Searched local files for active owner, workflow, deployment, package, and Azure references.
-- Created documentation and local workflow/Terraform changes. No repository transfer, archive, production app apply, deployment workflow run, package publication, or runtime app change was performed.
+- Historical Batch 1/2 note: created documentation and local workflow/Terraform changes without repository transfer, archive, production app apply, deployment workflow run, package publication, or runtime app change. Superseded on 2026-07-14 by Batch 3 transfer plus target-org deploy runs.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/reference-inventory.md
@@ -86,7 +86,7 @@ Action: preserve history; add current-location notes only where needed.
 
 ## Unknown Or Blocked References
 
-- Batch 3 target repository settings cannot be validated until `phoenixvc/cognitive-mesh` is transferred and `neuralliquid/cognitive-mesh` exists.
-- Target repository variables, secrets, environments, branch protections/rulesets, selected app installations, and Actions OIDC must be recreated or validated after transfer.
+- Batch 3 target repository settings were validated after `phoenixvc/cognitive-mesh` was transferred to `neuralliquid/cognitive-mesh`.
+- Target repository variables, secrets, environments, branch protections/rulesets, selected app installations, and Actions OIDC were validated without reading secret values.
 - Frontend App Service Terraform drift must be reconciled or explicitly accepted before any full production Terraform apply.
 - Direct model-provider secrets should remain quarantined; production model egress is routed through Sluice, with direct provider fallback disabled.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/rollback.md
@@ -4,12 +4,12 @@ Generated: 2026-07-13
 
 Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
 
-No repository transfer has been performed yet.
+Repository transfer was performed on 2026-07-14.
 
 ## Current Rollback State
 
-- Repository still exists at `phoenixvc/cognitive-mesh`.
-- Latest fetched `origin/dev` checked on 2026-07-14 is `792454d`.
+- Repository now exists at `neuralliquid/cognitive-mesh`; the old `phoenixvc/cognitive-mesh` path redirects to the transferred repository.
+- Latest fetched `origin/dev` checked on 2026-07-14 is `5e0567a`.
 - Batch 2 work is merged into `dev`; it includes the migration package, routing Terraform, Docket forwarding/auth settings, Sluice secret bridge durability, and OIDC readiness documentation.
 - Production App Services remain in `nl-prod-cognitive-mesh-rg`.
 - Deployment identity `nl-cognitive-mesh-github-actions` currently has PhoenixVC and NeuralLiquid repository federated subjects.
@@ -17,12 +17,13 @@ No repository transfer has been performed yet.
 - CogMesh production infrastructure keeps `enable_openai = false`.
 - Sluice is an external PhoenixVC-hosted dependency.
 - Docket canonical endpoint is live at `https://docket.phoenixvc.tech`.
+- Target-org API and frontend deploys succeeded from `neuralliquid/cognitive-mesh` and deployed `sha-5e0567a` images.
 
-## If Pre-Transfer Changes Need Reversal
+## If Post-Transfer Changes Need Reversal
 
 1. Stop any in-flight deploy workflows for Cognitive Mesh.
-2. Revert only the affected migration-prep commits or PRs.
-3. If changes are still local-only, discard or move only the Batch 2 migration/Terraform edits after confirming they are not user-owned work.
+2. Revert only the affected migration-prep commits or PRs from `neuralliquid/cognitive-mesh`.
+3. If changes are still local-only, discard or move only the migration documentation edits after confirming they are not user-owned work.
 4. Re-run Terraform validation and a prod plan before applying any infrastructure rollback.
 5. Confirm API and frontend health on the existing App Services.
 6. Update `handoff.md`, `verification.md` and Baton with the rollback evidence.

--- a/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
+++ b/docs/migrations/2026-neuralliquid-cognitive-mesh/verification.md
@@ -6,9 +6,9 @@ Scope: `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh`.
 
 ## Current Status
 
-Status: Batch 2 closeout complete for migration prep and Sluice/Docket routing; Batch 3 repository transfer not yet performed.
+Status: Batch 2 closeout complete; Batch 3 repository transfer completed and target-org deploys verified.
 
-Reason: Batch 2 migration artifacts, routing prep, deploy-workflow durability, Docket usage forwarding, Docket auth settings, and Sluice Key Vault reference wiring are merged into `dev`. Production and staging now report Sluice configured, direct provider fallback disabled, and Docket external auth configured. Repository transfer remains undone and is now the Batch 3 track through the Baton Migration Coordinator for org/OIDC/secrets/DNS work. Preserve the transfer block until the operator explicitly approves the irreversible GitHub transfer step.
+Reason: Batch 2 migration artifacts, routing prep, deploy-workflow durability, Docket usage forwarding, Docket auth settings, and Sluice Key Vault reference wiring are merged into `dev`. Production and staging report Sluice configured, direct provider fallback disabled, and Docket external auth configured. Batch 3 transferred the repository to `neuralliquid/cognitive-mesh`, validated target repository settings by name, confirmed NeuralLiquid OIDC subjects, and ran API/frontend deploys from the target org.
 
 ## Evidence Reviewed
 
@@ -100,15 +100,14 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - CogMesh-to-Docket code-level contract was implemented and production-smoked on 2026-07-14.
 - CogMesh-to-Sluice production auth was confirmed with the gateway key and is now wired through a Key Vault reference.
 - Selected GitHub App repository coverage was cleared by PAT-backed installation repository queries.
-- The remaining transfer gate is operational, not Batch 2 implementation: do not perform the irreversible GitHub repository transfer until explicitly approved for Batch 3 execution.
+- The remaining transfer gate was operational, not Batch 2 implementation. It was cleared when the operator approved Batch 3 execution on 2026-07-14.
 
 ## Next Verification Action
 
-1. Reconcile or explicitly accept frontend App Service Terraform drift before any full prod apply.
-2. Confirm final source repository state immediately before transfer.
-3. Perform the GitHub repository transfer to `neuralliquid/cognitive-mesh` only after explicit operator approval.
-4. Recreate/validate target repository variables, secrets, environments, app installations, branch protections/rulesets, and Actions OIDC.
-5. Run final deploys from the target org after target repository settings are validated.
+1. Review whether `mareeben` should be restored from write to admin on the transferred repository.
+2. Reconcile or explicitly accept frontend App Service Terraform drift before any full prod apply.
+3. Move NeuralLiquid-owned DNS/deployment state into NeuralLiquid-owned infrastructure before long-term production.
+4. Verify Docket-backed cost-attribution readiness from the Sluice-routed CogMesh usage path before using the transfer as funding evidence.
 
 ## Refresh - 2026-07-14
 
@@ -143,7 +142,7 @@ These checks verify status surfaces, not full live Sluice model execution or can
   - `repo:neuralliquid/cognitive-mesh:ref:refs/heads/main`
   - `repo:neuralliquid/cognitive-mesh:environment:production`
 - Verified both PhoenixVC and NeuralLiquid federated subjects are present on the deployment identity.
-- Verified `neuralliquid/cognitive-mesh` currently returns GitHub HTTP 404, so target-repository settings cannot be validated until the repository is transferred.
+- Historical pre-transfer check: `neuralliquid/cognitive-mesh` returned GitHub HTTP 404 before the repository transfer.
 - Captured current source repository variable and secret names for transfer validation; no secret values were recorded.
 
 ## Batch 2 Closeout Refresh - 2026-07-14
@@ -156,7 +155,7 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Confirmed production and staging `/api/v1/sluice/health` return `status=configured`, `sluiceConfigured=true`, `directProviderFallbackAllowed=false`, `docketConfigured=true`, and `docketMode=external-auth-configured`.
 - Confirmed production and staging App Service Key Vault references for `SLUICE_API_KEY` report `Resolved` through ARM config-reference reads.
 - Confirmed `https://docket.phoenixvc.tech/health` returns `{"status":"ok","backend":"table"}`.
-- Confirmed `neuralliquid/cognitive-mesh` still returns GitHub HTTP 404. Target-repo settings remain unvalidated because the repository has not been transferred.
+- Historical pre-transfer check: `neuralliquid/cognitive-mesh` still returned GitHub HTTP 404 before the repository transfer.
 
 ## Batch 3 Pre-Transfer Discovery - 2026-07-14
 
@@ -169,12 +168,42 @@ These checks verify status surfaces, not full live Sluice model execution or can
 - Source repository topics: `agent-orchestration`, `azure-openai`, `compliance`, `governance`, `observability`, `rbac`, `agent`, `ai`, `csharp`, `dotnet`, `reasoning`, `typescript`, `active`, `phoenixvc`, `neuralliquid`.
 - Source repository collaborators visible through GitHub: `mareeben` admin and `JustAGhosT` admin.
 - GitHub Pages endpoint returns 404, so no active Pages site was visible through the repository Pages API.
-- Target organization `neuralliquid` is visible; target repository `neuralliquid/cognitive-mesh` still returns GitHub HTTP 404.
+- Historical pre-transfer check: target organization `neuralliquid` was visible; target repository `neuralliquid/cognitive-mesh` still returned GitHub HTTP 404 before transfer.
 
-## Remaining Before Transfer
+## Batch 3 Transfer And Target Validation - 2026-07-14
 
-1. Baton Migration Coordinator: reconcile frontend App Service Terraform drift before any full prod apply.
-2. Baton Migration Coordinator: perform the actual GitHub repository transfer to `neuralliquid/cognitive-mesh` once explicitly approved.
-3. Baton Migration Coordinator: recreate/validate repository variables, secrets, environments, app installations, branch protections/rulesets, and DNS/custom-domain ownership after transfer.
+- Operator approved continuing Batch 3 with "lets go".
+- Transferred `phoenixvc/cognitive-mesh` to `neuralliquid/cognitive-mesh` through GitHub's repository transfer API.
+- Verified both old and new repository API paths resolve to `neuralliquid/cognitive-mesh`.
+- Updated local `origin` to `https://github.com/neuralliquid/cognitive-mesh.git`.
+- Verified target repository variables by name: `AZURE_WEBAPP_RESOURCE_GROUP`, `COGMESH_DOCKET_BASE_URL`, `COGMESH_SLUICE_API_KEY_SECRET_URI`, `COGMESH_SLUICE_BASE_URL`, `COGMESH_SLUICE_MAX_TOKENS`, `COGMESH_SLUICE_MODEL`, `COGNITIVE_MESH_API_APP_NAME`, `COGNITIVE_MESH_FRONTEND_APP_NAME`, `NEXT_PUBLIC_MYSTIRA_AUTH_CLIENT_ID`, and `NEXT_PUBLIC_MYSTIRA_TENANT_ID`.
+- Verified target repository secrets by name only: `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `COGMESH_DOCKET_API_KEY`, `SONAR_HOST_URL`, and `SONAR_TOKEN`.
+- Verified target repository environments: `copilot` and `production`; production has no protection rules or deployment branch policy.
+- Verified target repository ruleset `Main Branch Protection` (`13093301`) exists and remains disabled.
+- Verified target repository hooks list is empty, Pages endpoint returns 404, Actions are enabled, and workflows are active.
+- Verified visible target collaborators: `JustAGhosT` admin and `mareeben` write. Before transfer, `mareeben` appeared as admin; review whether this should be restored.
+- Verified OIDC app registration `nl-cognitive-mesh-github-actions` includes NeuralLiquid subjects:
+  - `repo:neuralliquid/cognitive-mesh:ref:refs/heads/dev`
+  - `repo:neuralliquid/cognitive-mesh:ref:refs/heads/main`
+  - `repo:neuralliquid/cognitive-mesh:environment:production`
+- Triggered and watched target-org deploy runs:
+  - API deploy run `29350528046`: succeeded.
+  - Frontend deploy run `29350528139`: succeeded.
+- Verified deployed App Service images through ARM:
+  - `DOCKER|myssharedacr.azurecr.io/cognitive-mesh-api:sha-5e0567a`
+  - `DOCKER|myssharedacr.azurecr.io/cognitive-mesh-frontend:sha-5e0567a`
+- Verified post-transfer health:
+  - API prod `/healthz`: `{"status":"ok"}`
+  - API staging `/healthz`: `{"status":"ok"}`
+  - Frontend prod `/api/health`: `{"status":"healthy"}`
+  - Frontend staging `/api/health`: `{"status":"healthy"}`
+  - Sluice health reports `status=configured`, `sluiceConfigured=true`, `directProviderFallbackAllowed=false`, `docketConfigured=true`, and `docketMode=external-auth-configured`.
+  - Docket health returns `{"status":"ok","backend":"table"}`.
+
+## Remaining After Transfer
+
+1. Review whether `mareeben` should be restored from write to admin on the transferred repository.
+2. Reconcile frontend App Service Terraform drift before any full prod Terraform apply.
+3. Move NeuralLiquid-owned DNS/deployment state into NeuralLiquid-owned infrastructure before long-term production.
 4. Baton FinOps and Runway Analyst: verify Docket-backed cost-attribution readiness from the Sluice-routed CogMesh usage path before using the transfer as funding evidence.
-5. Baton Evidence and Claims Auditor: validate that public migration/funding claims distinguish implemented Sluice/Docket routing from remaining transfer prerequisites.
+5. Baton Evidence and Claims Auditor: validate that public migration/funding claims distinguish implemented Sluice/Docket routing from remaining hardening tasks.


### PR DESCRIPTION
## Summary
- record the completed GitHub transfer from phoenixvc/cognitive-mesh to neuralliquid/cognitive-mesh
- capture target repo settings, OIDC subjects, target-org deploy runs, deployed images, and post-transfer health checks
- update rollback/handoff/manifest references so Batch 3 is the current transfer state

## Verification
- dotnet build CognitiveMesh.sln
- dotnet test CognitiveMesh.sln --no-build
- git diff --check
- API deploy run 29350528046 succeeded from neuralliquid/cognitive-mesh
- Frontend deploy run 29350528139 succeeded from neuralliquid/cognitive-mesh
- Post-transfer health checks passed for API prod/staging, frontend prod/staging, Sluice health, and Docket health

## Notes
No secret values were read or recorded. Remaining hardening: review mareeben repository permission, reconcile frontend App Service Terraform drift before full prod apply, and move long-term DNS/deployment ownership into NeuralLiquid-owned infra.